### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 <img src="assets/browserstack-logo.png" alt="BrowserStack Logo" height="100"> <img src="assets/mcp-logo.png" alt="MCP Server Logo" width="100">
 </div>
 
+<a href="https://glama.ai/mcp/servers/@browserstack/mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@browserstack/mcp-server/badge" alt="BrowserStack server MCP server" />
+</a>
+
 <div align="center">
 <a href="https://www.npmjs.com/package/@browserstack/mcp-server">
 <img alt="NPM Version" src="https://img.shields.io/npm/v/%40browserstack%2Fmcp-server">


### PR DESCRIPTION
This PR adds a badge for the [BrowserStack MCP server](https://glama.ai/mcp/servers/@browserstack/mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@browserstack/mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@browserstack/mcp-server/badge" alt="BrowserStack server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.