### PR TITLE
Bump version to 1.0.11 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserstack/mcp-server",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "BrowserStack's Official MCP Server",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
This pull request includes a version bump for the `@browserstack/mcp-server` package in the `package.json` file. The version has been updated from `1.0.10` to `1.0.11` to reflect the latest changes.