### PR TITLE
feat: enhance accessibility scan report with issue count

### DIFF
--- a/src/tools/accessibility.ts
+++ b/src/tools/accessibility.ts
@@ -48,13 +48,18 @@ async function runAccessibilityScan(
   // Fetch CSV report link
   const reportLink = await reportFetcher.getReportLink(scanId, scanRunId);
 
-  const { records } = await parseAccessibilityReportFromCSV(reportLink);
+  const { records, page_length, total_issues } =
+    await parseAccessibilityReportFromCSV(reportLink);
 
   return {
     content: [
       {
         type: "text",
         text: `✅ Accessibility scan "${name}" completed. check the BrowserStack dashboard for more details [https://scanner.browserstack.com/site-scanner/scan-details/${name}].`,
+      },
+      {
+        type: "text",
+        text: `We found ${total_issues} issues. Below are the details of the ${page_length} most critical issues.`,
       },
       {
         type: "text",

--- a/src/tools/accessiblity-utils/report-parser.ts
+++ b/src/tools/accessiblity-utils/report-parser.ts
@@ -20,6 +20,8 @@ type PaginationOptions = {
 type PaginatedResult = {
   records: SimplifiedAccessibilityIssue[];
   /** Character offset for the next page, or null if done */
+  page_length: number;
+  total_issues: number;
   next_page: number | null;
 };
 
@@ -42,6 +44,8 @@ export async function parseAccessibilityReportFromCSV(
     how_to_fix: row["How to fix this issue"],
     severity: (row["Severity"] || "unknown").trim(),
   }));
+
+  const totalIssues = all.length;
 
   // 2) Sort by severity
   const order: Record<string, number> = {
@@ -70,9 +74,13 @@ export async function parseAccessibilityReportFromCSV(
     charCursor += recStr.length;
   }
 
-  const hasMore = idx + page.length < all.length;
+  const pageLength = page.length;
+
+  const hasMore = idx + pageLength < totalIssues;
   return {
     records: page,
     next_page: hasMore ? charCursor : null,
+    page_length: pageLength,
+    total_issues: totalIssues,
   };
 }


### PR DESCRIPTION
This pull request enhances the accessibility scanning tool by including additional metadata in the scan results and improving the parsing logic for accessibility reports. The most important changes involve adding `page_length` and `total_issues` to the parsed report data and updating the scan result output to include these new details.