### PR TITLE
Feature: Add Local URL Support in Accessibility

### DIFF
--- a/src/lib/local.ts
+++ b/src/lib/local.ts
@@ -73,7 +73,7 @@ export async function killExistingBrowserStackLocalProcesses() {
   }
 }
 
-export async function ensureLocalBinarySetup(): Promise<void> {
+export async function ensureLocalBinarySetup(localIdentifier?: string): Promise<void> {
   logger.info(
     "Ensuring local binary setup as it is required for private URLs...",
   );
@@ -86,6 +86,7 @@ export async function ensureLocalBinarySetup(): Promise<void> {
       {
         key: config.browserstackAccessKey,
         username: config.browserstackUsername,
+        ...(localIdentifier ? { localIdentifier } : {}),
       },
       (error?: Error) => {
         if (error) {

--- a/src/lib/local.ts
+++ b/src/lib/local.ts
@@ -81,13 +81,22 @@ export async function ensureLocalBinarySetup(localIdentifier?: string): Promise<
   const localBinary = new Local();
   await killExistingBrowserStackLocalProcesses();
 
+  const requestBody: {
+    key: string;
+    username: string;
+    localIdentifier?: string;
+  } = {
+    key: config.browserstackAccessKey,
+    username: config.browserstackUsername
+  };
+
+  if (localIdentifier) {
+    requestBody.localIdentifier = localIdentifier;
+  }
+
   return await new Promise((resolve, reject) => {
     localBinary.start(
-      {
-        key: config.browserstackAccessKey,
-        username: config.browserstackUsername,
-        ...(localIdentifier ? { localIdentifier } : {}),
-      },
+      requestBody,
       (error?: Error) => {
         if (error) {
           logger.error(


### PR DESCRIPTION
#### Summary  
This PR adds support for testing **local/private URLs** (e.g., `127.0.0.1`) using **BrowserStack Local** in the accessibility (a11y) scanning flow. Developers can now scan websites hosted on their local machines without needing to deploy them publicly.

#### Usage Example  
To test a locally hosted website:

> Test accessibility for `127.0.0.1:5000` with project name "john's fashion".