### PR TITLE
feat: add USE_OWN_LOCAL_BINARY_PROCESS option to control local binary usage

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -30,12 +30,17 @@ for (const key of BROWSERSTACK_LOCAL_OPTION_KEYS) {
   }
 }
 
+/**
+ * USE_OWN_LOCAL_BINARY_PROCESS:
+ *   If true, the system will not start a new local binary process, but will use the user's own process.
+ */
 export class Config {
   constructor(
     public readonly browserstackUsername: string,
     public readonly browserstackAccessKey: string,
     public readonly DEV_MODE: boolean,
     public readonly browserstackLocalOptions: Record<string, any>,
+    public readonly USE_OWN_LOCAL_BINARY_PROCESS: boolean,
   ) {}
 }
 
@@ -44,6 +49,7 @@ const config = new Config(
   process.env.BROWSERSTACK_ACCESS_KEY!,
   process.env.DEV_MODE === "true",
   browserstackLocalOptions,
+  process.env.USE_OWN_LOCAL_BINARY_PROCESS === "true",
 );
 
 export default config;

--- a/src/lib/local.ts
+++ b/src/lib/local.ts
@@ -80,6 +80,13 @@ export async function ensureLocalBinarySetup(
     "Ensuring local binary setup as it is required for private URLs...",
   );
 
+  if (config.USE_OWN_LOCAL_BINARY_PROCESS) {
+    logger.info(
+      "Using user's own BrowserStack Local binary process, skipping setup...",
+    );
+    return;
+  }
+  
   const localBinary = new Local();
   await killExistingBrowserStackLocalProcesses();
 

--- a/src/lib/local.ts
+++ b/src/lib/local.ts
@@ -86,7 +86,7 @@ export async function ensureLocalBinarySetup(
     );
     return;
   }
-  
+
   const localBinary = new Local();
   await killExistingBrowserStackLocalProcesses();
 

--- a/src/lib/local.ts
+++ b/src/lib/local.ts
@@ -82,7 +82,18 @@ export async function ensureLocalBinarySetup(
 
   if (config.USE_OWN_LOCAL_BINARY_PROCESS) {
     logger.info(
-      "Using user's own BrowserStack Local binary process, skipping setup...",
+      "Using user's own BrowserStack Local binary process, checking if it's running...",
+    );
+
+    const isRunning = await isBrowserStackLocalRunning();
+    if (!isRunning) {
+      throw new Error(
+        "USE_OWN_LOCAL_BINARY_PROCESS is enabled but BrowserStack Local process is not running. Please start your BrowserStack Local binary process first.",
+      );
+    }
+
+    logger.info(
+      "BrowserStack Local process is running, proceeding with user's own process.",
     );
     return;
   }

--- a/src/tools/accessiblity-utils/scanner.ts
+++ b/src/tools/accessiblity-utils/scanner.ts
@@ -35,7 +35,7 @@ export class AccessibilityScanner {
     const localHosts = new Set(["127.0.0.1", "localhost", "0.0.0.0"]);
     const BS_LOCAL_DOMAIN = "bs-local.com";
 
-    if (config.USE_OWN_LOCAL_BINARY_PROCESS) {
+    if (config.USE_OWN_LOCAL_BINARY_PROCESS && hasLocal) {
       throw new Error(
         "Cannot start scan with local URLs when using own BrowserStack Local binary process. Please set USE_OWN_LOCAL_BINARY_PROCESS to false.",
       );

--- a/src/tools/accessiblity-utils/scanner.ts
+++ b/src/tools/accessiblity-utils/scanner.ts
@@ -35,16 +35,17 @@ export class AccessibilityScanner {
     const localHosts = new Set(["127.0.0.1", "localhost", "0.0.0.0"]);
     const BS_LOCAL_DOMAIN = "bs-local.com";
 
-    if (hasLocal) {
-      await ensureLocalBinarySetup(localIdentifier);
-    } else {
-      await killExistingBrowserStackLocalProcesses();
-    }
-
     if (config.USE_OWN_LOCAL_BINARY_PROCESS) {
       throw new Error(
         "Cannot start scan with local URLs when using own BrowserStack Local binary process. Please set USE_OWN_LOCAL_BINARY_PROCESS to false.",
       );
+    }
+
+    
+    if (hasLocal) {
+      await ensureLocalBinarySetup(localIdentifier);
+    } else {
+      await killExistingBrowserStackLocalProcesses();
     }
 
     const transformedUrlList = urlList.map((url) => {

--- a/src/tools/accessiblity-utils/scanner.ts
+++ b/src/tools/accessiblity-utils/scanner.ts
@@ -41,6 +41,12 @@ export class AccessibilityScanner {
       await killExistingBrowserStackLocalProcesses();
     }
 
+    if (config.USE_OWN_LOCAL_BINARY_PROCESS) {
+      throw new Error(
+        "Cannot start scan with local URLs when using own BrowserStack Local binary process. Please set USE_OWN_LOCAL_BINARY_PROCESS to false.",
+      );
+    }
+
     const transformedUrlList = urlList.map((url) => {
       try {
         const parsed = new URL(url);

--- a/src/tools/accessiblity-utils/scanner.ts
+++ b/src/tools/accessiblity-utils/scanner.ts
@@ -41,7 +41,6 @@ export class AccessibilityScanner {
       );
     }
 
-    
     if (hasLocal) {
       await ensureLocalBinarySetup(localIdentifier);
     } else {


### PR DESCRIPTION
This pull request introduces a new configuration option, `USE_OWN_LOCAL_BINARY_PROCESS`, to allow users to use their own BrowserStack Local binary process instead of starting a new one. The changes include updates to the configuration class, conditional logic in the local binary setup, and error handling in the accessibility scanner. Below is a summary of the most important changes:

### Configuration Updates:
* Added a new property, `USE_OWN_LOCAL_BINARY_PROCESS`, to the `Config` class in `src/config.ts`, allowing users to specify whether to use their own BrowserStack Local binary process. This is set based on the environment variable `USE_OWN_LOCAL_BINARY_PROCESS`. [[1]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R33-R43) [[2]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R52)

### Local Binary Setup:
* Updated the `ensureLocalBinarySetup` function in `src/lib/local.ts` to skip the setup process if `USE_OWN_LOCAL_BINARY_PROCESS` is enabled, logging a message to indicate this behavior.

### Accessibility Scanner:
* Added error handling in the `AccessibilityScanner` class in `src/tools/accessiblity-utils/scanner.ts` to prevent scanning with local URLs when `USE_OWN_LOCAL_BINARY_PROCESS` is enabled, throwing an error with a clear message.