### PR TITLE
refactor: update SDK setup to use config and improve instructions

### DIFF
--- a/src/tools/sdk-utils/commands.ts
+++ b/src/tools/sdk-utils/commands.ts
@@ -1,6 +1,6 @@
 // Utility to get the language-dependent prefix command for BrowserStack SDK setup
 import { SDKSupportedLanguage } from "./types.js";
-
+import config from "../../config.js";
 // Framework mapping for Java Maven archetype generation
 const JAVA_FRAMEWORK_MAP: Record<string, string> = {
   testng: "testng",
@@ -36,7 +36,7 @@ npm i -D browserstack-node-sdk@latest
 ---STEP---
 Run the following command to setup browserstack sdk:
 \`\`\`bash
-npx setup --username ${process.env.BROWSERSTACK_USERNAME} --key ${process.env.BROWSERSTACK_ACCESS_KEY}
+npx setup --username ${config.browserstackUsername} --key ${config.browserstackAccessKey}
 \`\`\`
 ---STEP---
 Edit the browserstack.yml file that was created in the project root to add your desired platforms and browsers.`;
@@ -46,12 +46,12 @@ Edit the browserstack.yml file that was created in the project root to add your 
       const isWindows = process.platform === "win32";
 
       const mavenCommand = isWindows
-        ? `mvn archetype:generate -B -DarchetypeGroupId="com.browserstack" -DarchetypeArtifactId="browserstack-sdk-archetype-integrate" -DarchetypeVersion="1.0" -DgroupId="com.browserstack" -DartifactId="browserstack-sdk-archetype-integrate" -Dversion="1.0" -DBROWSERSTACK_USERNAME="${process.env.BROWSERSTACK_USERNAME}" -DBROWSERSTACK_ACCESS_KEY="${process.env.BROWSERSTACK_ACCESS_KEY}" -DBROWSERSTACK_FRAMEWORK="${mavenFramework}"`
+        ? `mvn archetype:generate -B -DarchetypeGroupId="com.browserstack" -DarchetypeArtifactId="browserstack-sdk-archetype-integrate" -DarchetypeVersion="1.0" -DgroupId="com.browserstack" -DartifactId="browserstack-sdk-archetype-integrate" -Dversion="1.0" -DBROWSERSTACK_USERNAME="${config.browserstackUsername}" -DBROWSERSTACK_ACCESS_KEY="${config.browserstackAccessKey}" -DBROWSERSTACK_FRAMEWORK="${mavenFramework}"`
         : `mvn archetype:generate -B -DarchetypeGroupId=com.browserstack \\
 -DarchetypeArtifactId=browserstack-sdk-archetype-integrate -DarchetypeVersion=1.0 \\
 -DgroupId=com.browserstack -DartifactId=browserstack-sdk-archetype-integrate -Dversion=1.0 \\
--DBROWSERSTACK_USERNAME="${process.env.BROWSERSTACK_USERNAME}" \\
--DBROWSERSTACK_ACCESS_KEY="${process.env.BROWSERSTACK_ACCESS_KEY}" \\
+-DBROWSERSTACK_USERNAME="${config.browserstackUsername}" \\
+-DBROWSERSTACK_ACCESS_KEY="${config.browserstackAccessKey}" \\
 -DBROWSERSTACK_FRAMEWORK="${mavenFramework}"`;
 
       const platformLabel = isWindows ? "Windows" : "macOS/Linux";

--- a/src/tools/sdk-utils/constants.ts
+++ b/src/tools/sdk-utils/constants.ts
@@ -315,8 +315,8 @@ Here is an example configuration:
 \`\`\`javascript
 exports.config = {
   // Set your BrowserStack credentials
-  user: process.env.BROWSERSTACK_USERNAME,
-  key: process.env.BROWSERSTACK_ACCESS_KEY,
+  user: ${config.browserstackUsername},
+  key: ${config.browserstackAccessKey},
 
   // Set BrowserStack hostname
   hostname: 'hub.browserstack.com',

--- a/src/tools/sdk-utils/instructions.ts
+++ b/src/tools/sdk-utils/instructions.ts
@@ -46,10 +46,10 @@ export function generateBrowserStackYMLInstructions(
 # ======================
 # BrowserStack Reporting
 # ======================
-# A single name for your project to organize all your tests. This is required for Percy.
-projectName: BrowserStack SDK Tests
-# A name for the group of tests you are running
-buildName: mcp-run
+# Project and build names help organize your test runs in BrowserStack dashboard and Percy.
+# TODO: Replace these sample values with your actual project details
+projectName: Sample Project
+buildName: Sample Build
 
 # =======================================
 # Platforms (Browsers / Devices to test)


### PR DESCRIPTION
This pull request updates the BrowserStack SDK setup process by replacing environment variable usage with a centralized configuration object. The changes improve maintainability and make it easier to manage credentials and settings across the SDK. Below are the most important changes grouped by theme:

### Refactoring to use centralized configuration:

* Updated `src/tools/sdk-utils/commands.ts` to import `config` from `../../config.js` and replaced `process.env.BROWSERSTACK_USERNAME` and `process.env.BROWSERSTACK_ACCESS_KEY` with `config.browserstackUsername` and `config.browserstackAccessKey` in SDK setup commands. [[1]](diffhunk://#diff-e3f6c3f1feb32a175156b0512129d4cfa14184442439071858af59aca98a15ddL3-R3) [[2]](diffhunk://#diff-e3f6c3f1feb32a175156b0512129d4cfa14184442439071858af59aca98a15ddL39-R39) [[3]](diffhunk://#diff-e3f6c3f1feb32a175156b0512129d4cfa14184442439071858af59aca98a15ddL49-R54)
* Modified `src/tools/sdk-utils/constants.ts` to use `config.browserstackUsername` and `config.browserstackAccessKey` for defining credentials in example configurations.

### Updates to instructions:

* Revised `src/tools/sdk-utils/instructions.ts` to include clearer placeholders for project and build names, replacing hardcoded values with sample values and adding comments for customization.