### PR TITLE
fix: bump axios to ^1.15.0 to patch NO_PROXY SSRF bypass (PMAA-94)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserstack/mcp-server",
-      "version": "1.2.14",
+      "version": "1.2.15",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@types/form-data": "^2.5.2",
-        "axios": "^1.14.0",
+        "axios": "^1.15.0",
         "browserstack-local": "^1.5.12",
         "csv-parse": "^6.2.1",
         "dotenv": "^17.4.0",
@@ -1557,9 +1557,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/form-data": "^2.5.2",
-    "axios": "^1.14.0",
+    "axios": "^1.15.0",
     "browserstack-local": "^1.5.12",
     "csv-parse": "^6.2.1",
     "dotenv": "^17.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "BrowserStack's Official MCP Server",
   "mcpName": "io.github.browserstack/mcp-server",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@browserstack/mcp-server",
-      "version": "1.2.14",
+      "version": "1.2.15",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Bumps `axios` from **1.14.0 → 1.15.0** to remediate [GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5) / [CVE-2025-62718](https://nvd.nist.gov/vuln/detail/CVE-2025-62718) — **NO_PROXY hostname-normalization bypass leading to SSRF** (CVSSv4 **9.3, critical**).
- Tracks [PMAA-94](https://browserstack.atlassian.net/browse/PMAA-94).

## Vulnerability
Axios `<1.15.0` did a literal string comparison against `NO_PROXY` and did not normalize hostnames. Requests to `http://localhost.:PORT/` (trailing dot) or `http://[::1]:PORT/` (IPv6 literal) skipped `NO_PROXY` matching and were routed through the configured proxy — enabling SSRF / proxy-bypass when apps relied on `NO_PROXY=localhost,127.0.0.1,::1` to protect loopback services.

Fixed upstream by [axios/axios#10661](https://github.com/axios/axios/pull/10661), released in [v1.15.0](https://github.com/axios/axios/releases/tag/v1.15.0).

## Changes
- `package.json`: `axios: "^1.14.0"` → `"^1.15.0"`
- `package-lock.json`: regenerated for axios 1.15.0

No source changes required — the fix lives inside axios' `NO_PROXY` evaluation logic, which our `src/lib/apiClient.ts` wrapper consumes transparently.

## Impact assessment
- axios 1.15.0 is a **minor** release over 1.14.0 (no breaking API changes per axios changelog).
- Our repo's only axios consumers are `src/lib/apiClient.ts` and `src/lib/error.ts` (+ a test file). The public surface (`AxiosRequestConfig`, `AxiosResponse`, `axios.create`, per-verb methods, `httpsAgent`) is unchanged.
- Typechecker (`tsc --noEmit`) passes clean.
- Full test suite: **16 files / 123 tests passing**.
- `npm audit` surfaces 4 other unrelated advisories (vite, hono, @hono/node-server, basic-ftp) — out of scope for this ticket.

## Verification
Ran a local verification harness (not committed) against the upgraded axios:

1. **Basic GET still works** — `axios.get("https://api.github.com/zen")` → `200 OK` ✅
2. **NO_PROXY bypass fix confirmed** — started a local proxy, set `HTTP_PROXY=http://127.0.0.1:<port>` and `NO_PROXY=localhost,127.0.0.1,::1`, then issued requests to `http://localhost.:9999/` and `http://[::1]:9999/`. The proxy received **zero** hits, confirming axios 1.15.0 correctly normalizes trailing-dot hostnames and IPv6 literals before matching `NO_PROXY`. On axios 1.14.0 both requests would have been routed to the proxy. ✅

```
axios version: 1.15.0
[OK] Basic GET: 200 "Practicality beats purity."
[OK] NO_PROXY correctly honored for localhost. and [::1] (proxy not hit)
```

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npm test` — 123/123 passing
- [x] Local PoC from the advisory no longer reproduces
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PMAA-94]: https://browserstack.atlassian.net/browse/PMAA-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ