### PR TITLE
fix(percy): disable runPercyScan

### DIFF
--- a/src/tools/percy-sdk.ts
+++ b/src/tools/percy-sdk.ts
@@ -2,7 +2,8 @@ import { trackMCP } from "../index.js";
 import { BrowserStackConfig } from "../lib/types.js";
 import { fetchPercyChanges } from "./review-agent.js";
 import { addListTestFiles } from "./list-test-files.js";
-import { runPercyScan } from "./run-percy-scan.js";
+// PMAA-100: runPercyScan tool temporarily disabled due to plaintext token leak in tool output.
+// import { runPercyScan } from "./run-percy-scan.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SetUpPercyParamsShape } from "./sdk-utils/common/schema.js";
 import { updateTestsWithPercyCommands } from "./add-percy-snapshots.js";
@@ -21,7 +22,8 @@ import {
 import { UpdateTestFileWithInstructionsParams } from "./percy-snapshot-utils/constants.js";
 
 import {
-  RunPercyScanParamsShape,
+  // PMAA-100: kept commented so the registration block below is easy to restore once the proper fix lands.
+  // RunPercyScanParamsShape,
   FetchPercyChangesParamsShape,
   ManagePercyBuildApprovalParamsShape,
 } from "./sdk-utils/common/schema.js";
@@ -133,19 +135,22 @@ export function registerPercyTools(
     },
   );
 
-  tools.runPercyScan = server.tool(
-    "runPercyScan",
-    "Run a Percy visual test scan. Example prompts : Run this Percy build/scan. Never run percy scan/build without this tool",
-    RunPercyScanParamsShape,
-    async (args) => {
-      try {
-        trackMCP("runPercyScan", server.server.getClientVersion()!, config);
-        return runPercyScan(args, config);
-      } catch (error) {
-        return handleMCPError("runPercyScan", server, config, error);
-      }
-    },
-  );
+  // PMAA-100: runPercyScan temporarily disabled — fetched Percy token was being
+  // returned in plaintext within tool output (see HackerOne #3576387). Re-enable
+  // once the token is replaced with a placeholder in run-percy-scan.ts.
+  // tools.runPercyScan = server.tool(
+  //   "runPercyScan",
+  //   "Run a Percy visual test scan. Example prompts : Run this Percy build/scan. Never run percy scan/build without this tool",
+  //   RunPercyScanParamsShape,
+  //   async (args) => {
+  //     try {
+  //       trackMCP("runPercyScan", server.server.getClientVersion()!, config);
+  //       return runPercyScan(args, config);
+  //     } catch (error) {
+  //       return handleMCPError("runPercyScan", server, config, error);
+  //     }
+  //   },
+  // );
 
   tools.fetchPercyChanges = server.tool(
     "fetchPercyChanges",

--- a/tests/tools/percySdk.test.ts
+++ b/tests/tools/percySdk.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { registerPercyTools } from "../../src/tools/percy-sdk";
 import { setUpPercyHandler, simulatePercyChangeHandler } from "../../src/tools/sdk-utils/handler";
 import { updateTestsWithPercyCommands } from "../../src/tools/add-percy-snapshots";
-import { runPercyScan } from "../../src/tools/run-percy-scan";
+// PMAA-100: runPercyScan registration disabled — restore import alongside the test.
+// import { runPercyScan } from "../../src/tools/run-percy-scan";
 import { fetchPercyChanges } from "../../src/tools/review-agent";
 import { approveOrDeclinePercyBuild } from "../../src/tools/review-agent-utils/percy-approve-reject";
 
@@ -13,9 +14,10 @@ vi.mock("../../src/tools/sdk-utils/handler", () => ({
 vi.mock("../../src/tools/add-percy-snapshots", () => ({
   updateTestsWithPercyCommands: vi.fn(),
 }));
-vi.mock("../../src/tools/run-percy-scan", () => ({
-  runPercyScan: vi.fn(),
-}));
+// PMAA-100: runPercyScan registration disabled — restore mock alongside the test.
+// vi.mock("../../src/tools/run-percy-scan", () => ({
+//   runPercyScan: vi.fn(),
+// }));
 vi.mock("../../src/tools/review-agent", () => ({
   fetchPercyChanges: vi.fn(),
 }));
@@ -64,7 +66,8 @@ describe("Percy SDK Tools", () => {
     expect(toolNames).toContain("expandPercyVisualTesting");
     expect(toolNames).toContain("addPercySnapshotCommands");
     expect(toolNames).toContain("listTestFiles");
-    expect(toolNames).toContain("runPercyScan");
+    // PMAA-100: runPercyScan registration disabled — restore once the token leak is fixed.
+    // expect(toolNames).toContain("runPercyScan");
     expect(toolNames).toContain("fetchPercyChanges");
     expect(toolNames).toContain("managePercyBuildApproval");
   });
@@ -118,14 +121,15 @@ describe("Percy SDK Tools", () => {
     expect(result.content[0].text).toContain("Commands added");
   });
 
-  it("runPercyScan - SUCCESS", async () => {
-    (runPercyScan as any).mockResolvedValue({
-      content: [{ type: "text", text: "Percy scan started" }],
-    });
-
-    const result = await handlers["runPercyScan"]({ projectName: "test" });
-    expect(result.content[0].text).toContain("Percy scan");
-  });
+  // PMAA-100: runPercyScan registration disabled — restore once the token leak is fixed.
+  // it("runPercyScan - SUCCESS", async () => {
+  //   (runPercyScan as any).mockResolvedValue({
+  //     content: [{ type: "text", text: "Percy scan started" }],
+  //   });
+  //
+  //   const result = await handlers["runPercyScan"]({ projectName: "test" });
+  //   expect(result.content[0].text).toContain("Percy scan");
+  // });
 
   it("fetchPercyChanges - SUCCESS", async () => {
     (fetchPercyChanges as any).mockResolvedValue({


### PR DESCRIPTION
## Summary
- Temporary fix for **PMAA-100** / HackerOne #3576387: `runPercyScan` was embedding the server-fetched Percy token in plaintext inside the tool response (`export PERCY_TOKEN="<actual_token>"`).
- Disables the `runPercyScan` MCP tool registration in `src/tools/percy-sdk.ts` so the leaking code path is no longer reachable via `tools/list` / `tools/call`.
- Underlying source (`src/tools/run-percy-scan.ts`) is untouched — it remains exported and unit-tested. The proper fix (replacing the interpolated token with a placeholder) will land in the planned sprint per Gaurav's note on the ticket.
- Note: a similar plaintext-token emission pattern exists in `src/tools/sdk-utils/percy-web/handler.ts` (called from `expandPercyVisualTesting`). Reporter flagged it under "Code References" in the original H1 submission. Out of scope for this temp fix per Pradum's instruction; should be addressed in the proper-fix PR.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm test` — 122/122 pass
- [ ] Reviewer: confirm `runPercyScan` no longer appears in `tools/list` from a connected MCP client