### PR TITLE
fix(accessibility): redact password in createAccessibilityAuthConfig log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserstack/mcp-server",
-      "version": "1.2.16",
+      "version": "1.2.17",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "BrowserStack's Official MCP Server",
   "mcpName": "io.github.browserstack/mcp-server",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@browserstack/mcp-server",
-      "version": "1.2.16",
+      "version": "1.2.17",
       "transport": {
         "type": "stdio"
       },

--- a/src/tools/accessibility.ts
+++ b/src/tools/accessibility.ts
@@ -280,7 +280,9 @@ async function executeCreateAuthConfig(
       undefined,
       config,
     );
-    logger.info(`Creating auth config: ${JSON.stringify(args)}`);
+    logger.info(
+      `Creating auth config: ${JSON.stringify({ ...args, password: "***" })}`,
+    );
 
     const result = await createAuthConfig(args, config);
 


### PR DESCRIPTION
## Summary
- Replace `JSON.stringify(args)` in `createAccessibilityAuthConfig` with a redacted copy so plaintext passwords never reach the log stream.
- Bump version 1.2.16 → 1.2.17 (package.json, package-lock.json, server.json).

## Test plan
- [x] `npm run build` (lint + format + 147 tests + tsc) passes locally
- [ ] CI green