### PR TITLE
feat(testmanagement): add listSubTestPlans and getSubTestPlan MCP tools

### DIFF
--- a/src/tools/testmanagement-utils/get-sub-testplan.ts
+++ b/src/tools/testmanagement-utils/get-sub-testplan.ts
@@ -1,0 +1,218 @@
+import { apiClient } from "../../lib/apiClient.js";
+import { z } from "zod";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { formatAxiosError } from "../../lib/error.js";
+import { getBrowserStackAuth } from "../../lib/get-auth.js";
+import { BrowserStackConfig } from "../../lib/types.js";
+import { getTMBaseURL } from "../../lib/tm-base-url.js";
+
+/**
+ * Schema for fetching a single sub-test-plan by identifier under a parent test
+ * plan, including its linked test runs.
+ */
+export const GetSubTestPlanSchema = z.object({
+  project_identifier: z.string().describe("Project identifier (PR-*)."),
+  parent_test_plan_identifier: z
+    .string()
+    .describe("Parent test plan identifier (TP-*)."),
+  sub_test_plan_identifier: z
+    .string()
+    .describe("Sub-test-plan identifier (STP-*)."),
+});
+
+export type GetSubTestPlanArgs = z.infer<typeof GetSubTestPlanSchema>;
+
+interface SubTestPlan {
+  identifier: string;
+  name: string;
+  active_state: string;
+  description: string | null;
+  project_id: string;
+  parent_plan_id: string;
+  start_date: string | null;
+  end_date: string | null;
+  created_at: string;
+  test_runs_count?: { active: number; closed: number };
+  test_runs?: Array<{ identifier: string; name: string }>;
+  links?: Record<string, string>;
+  tags?: string[];
+  issues?: string[] | null;
+}
+
+interface LinkedTestRun {
+  identifier: string;
+  name: string;
+  run_state: string;
+  active_state: string;
+  assignee?: string | null;
+  description?: string | null;
+  created_at: string;
+  project_id: string;
+  test_cases_count: number;
+}
+
+// Validates host parity with the TM base URL to prevent SSRF if `links.test_runs`
+// ever resolves to an absolute URL pointing elsewhere.
+//
+// The constructed fallback uses the flat shape `/test-plans/{STP}/test-runs`
+// (not nested under the parent) because that is the form the v2 API itself
+// returns in `sub_test_plan.links.test_runs`. The parent identifier deliberately
+// does NOT appear in this URL.
+function resolveEnrichmentUrl(
+  linksTestRuns: string | undefined,
+  tmBaseUrl: string,
+  projectId: string,
+  subPlanId: string,
+): string {
+  if (typeof linksTestRuns === "string" && linksTestRuns.length > 0) {
+    if (linksTestRuns.startsWith("/")) {
+      // Relative path — safe to join under tmBaseUrl.
+      return `${tmBaseUrl}${linksTestRuns}`;
+    }
+    if (
+      linksTestRuns.startsWith("http://") ||
+      linksTestRuns.startsWith("https://")
+    ) {
+      try {
+        const linkUrl = new URL(linksTestRuns);
+        const baseUrl = new URL(tmBaseUrl);
+        if (linkUrl.host === baseUrl.host) {
+          return linksTestRuns;
+        }
+      } catch {
+        // Fall through to constructed fallback.
+      }
+    }
+  }
+  return `${tmBaseUrl}/api/v2/projects/${projectId}/test-plans/${subPlanId}/test-runs`;
+}
+
+/**
+ * Fetches a sub-test-plan by identifier and best-effort-enriches it with its
+ * linked test runs. The enrichment call is fail-soft: any failure (thrown
+ * AxiosError or non-success response) is swallowed into an empty runs list
+ * without flipping `isError` on the primary response.
+ */
+export async function getSubTestPlan(
+  args: GetSubTestPlanArgs,
+  config: BrowserStackConfig,
+): Promise<CallToolResult> {
+  try {
+    const tmBaseUrl = await getTMBaseURL(config);
+    const projectId = encodeURIComponent(args.project_identifier);
+    const parentPlanId = encodeURIComponent(args.parent_test_plan_identifier);
+    const subPlanId = encodeURIComponent(args.sub_test_plan_identifier);
+
+    const authString = getBrowserStackAuth(config);
+    const [username, password] = authString.split(":");
+    const authHeader =
+      "Basic " + Buffer.from(`${username}:${password}`).toString("base64");
+
+    const planResp = await apiClient.get({
+      url: `${tmBaseUrl}/api/v2/projects/${projectId}/test-plans/${parentPlanId}/sub-test-plans/${subPlanId}`,
+      headers: { Authorization: authHeader },
+    });
+
+    if (!planResp.data?.success) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Failed to fetch sub-test-plan: ${JSON.stringify(planResp.data)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const plan: SubTestPlan = planResp.data.sub_test_plan;
+
+    const enrichmentUrl = resolveEnrichmentUrl(
+      plan.links?.test_runs,
+      tmBaseUrl,
+      projectId,
+      subPlanId,
+    );
+
+    let runs: LinkedTestRun[] = [];
+    try {
+      const runsResp = await apiClient.get({
+        url: enrichmentUrl,
+        headers: { Authorization: authHeader },
+      });
+      if (runsResp.data?.success) {
+        runs = runsResp.data.test_runs ?? [];
+      }
+    } catch {
+      // Enrichment is best-effort — leave runs empty.
+    }
+
+    const statusSummary: Record<string, number> = {};
+    let totalCases = 0;
+    for (const run of runs) {
+      statusSummary[run.run_state] = (statusSummary[run.run_state] ?? 0) + 1;
+      totalCases += run.test_cases_count ?? 0;
+    }
+
+    const tagsLine =
+      Array.isArray(plan.tags) && plan.tags.length > 0
+        ? `Tags: ${plan.tags.join(", ")}`
+        : null;
+    const issuesLine =
+      Array.isArray(plan.issues) && plan.issues.length > 0
+        ? `Issues: ${plan.issues.join(", ")}`
+        : null;
+
+    const header = [
+      `Sub-Test-Plan ${plan.identifier}: ${plan.name}`,
+      `Parent plan: ${plan.parent_plan_id}`,
+      `Status: ${plan.active_state}`,
+      plan.description ? `Description: ${plan.description}` : null,
+      tagsLine,
+      issuesLine,
+      plan.start_date || plan.end_date
+        ? `Dates: ${plan.start_date ?? "—"} → ${plan.end_date ?? "—"}`
+        : null,
+      `Linked runs: ${runs.length} (plan counts — active ${plan.test_runs_count?.active ?? 0} / closed ${plan.test_runs_count?.closed ?? 0})`,
+      `Total test cases across runs: ${totalCases}`,
+      Object.keys(statusSummary).length > 0
+        ? `Run-state breakdown: ${Object.entries(statusSummary)
+            .map(([s, n]) => `${s}=${n}`)
+            .join(", ")}`
+        : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    const runsBlock = runs.length
+      ? "\n\nLinked test runs:\n" +
+        runs
+          .map(
+            (r) =>
+              `• ${r.identifier}: ${r.name} [${r.run_state}] — ${r.test_cases_count} case(s)${r.assignee ? ` (assignee: ${r.assignee})` : ""}`,
+          )
+          .join("\n")
+      : "\n\nNo test runs linked to this sub-plan.";
+
+    return {
+      content: [
+        { type: "text", text: header + runsBlock },
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              sub_test_plan: plan,
+              linked_test_runs: runs,
+              status_summary: statusSummary,
+              total_test_cases: totalCases,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  } catch (err) {
+    return formatAxiosError(err, "Failed to fetch sub-test-plan");
+  }
+}

--- a/src/tools/testmanagement-utils/list-sub-testplans.ts
+++ b/src/tools/testmanagement-utils/list-sub-testplans.ts
@@ -1,0 +1,114 @@
+import { apiClient } from "../../lib/apiClient.js";
+import { z } from "zod";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { formatAxiosError } from "../../lib/error.js";
+import { getBrowserStackAuth } from "../../lib/get-auth.js";
+import { BrowserStackConfig } from "../../lib/types.js";
+import { getTMBaseURL } from "../../lib/tm-base-url.js";
+
+/**
+ * Schema for listing sub-test-plans under a parent test plan in a BrowserStack
+ * Test Management project.
+ */
+export const ListSubTestPlansSchema = z.object({
+  project_identifier: z.string().describe("Project identifier (PR-*)."),
+  parent_test_plan_identifier: z
+    .string()
+    .describe("Parent test plan identifier (TP-*)."),
+  p: z.number().optional().describe("Page number."),
+});
+
+export type ListSubTestPlansArgs = z.infer<typeof ListSubTestPlansSchema>;
+
+interface SubTestPlanListItem {
+  identifier: string;
+  name: string;
+  active_state: string;
+  description: string | null;
+  project_id: string;
+  parent_plan_id: string;
+  start_date: string | null;
+  end_date: string | null;
+  created_at: string;
+  test_runs_count?: { active: number; closed: number };
+  tags?: string[];
+  issues?: string[];
+}
+
+/**
+ * Lists sub-test-plans under a parent test plan in BrowserStack Test Management.
+ */
+export async function listSubTestPlans(
+  args: ListSubTestPlansArgs,
+  config: BrowserStackConfig,
+): Promise<CallToolResult> {
+  try {
+    const params = new URLSearchParams();
+    if (args.p !== undefined) params.append("p", args.p.toString());
+
+    const tmBaseUrl = await getTMBaseURL(config);
+    const projectId = encodeURIComponent(args.project_identifier);
+    const parentPlanId = encodeURIComponent(args.parent_test_plan_identifier);
+    const url = `${tmBaseUrl}/api/v2/projects/${projectId}/test-plans/${parentPlanId}/sub-test-plans?${params.toString()}`;
+
+    const authString = getBrowserStackAuth(config);
+    const [username, password] = authString.split(":");
+    const resp = await apiClient.get({
+      url,
+      headers: {
+        Authorization:
+          "Basic " + Buffer.from(`${username}:${password}`).toString("base64"),
+      },
+    });
+
+    const data = resp.data;
+    if (!data.success) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Failed to list sub-test-plans: ${JSON.stringify(data)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const plans: SubTestPlanListItem[] = data.sub_test_plans ?? [];
+    const info = data.info ?? {};
+    const count = info.count ?? plans.length;
+
+    if (plans.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `No sub-test-plans found under ${args.parent_test_plan_identifier} in project ${args.project_identifier}.`,
+          },
+        ],
+      };
+    }
+
+    const summary = plans
+      .map((p) => {
+        const tagsSegment =
+          Array.isArray(p.tags) && p.tags.length > 0
+            ? ` — tags: [${p.tags.join(", ")}]`
+            : "";
+        return `• ${p.identifier}: ${p.name} [${p.active_state}] — ${p.test_runs_count?.active ?? 0} active / ${p.test_runs_count?.closed ?? 0} closed run(s)${tagsSegment}`;
+      })
+      .join("\n");
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Found ${count} sub-test-plan(s) under ${args.parent_test_plan_identifier} in project ${args.project_identifier}:\n\n${summary}`,
+        },
+        { type: "text", text: JSON.stringify(plans, null, 2) },
+      ],
+    };
+  } catch (err) {
+    return formatAxiosError(err, "Failed to list sub-test-plans");
+  }
+}

--- a/src/tools/testmanagement.ts
+++ b/src/tools/testmanagement.ts
@@ -73,6 +73,16 @@ import {
   GetTestPlanSchema,
 } from "./testmanagement-utils/get-testplan.js";
 
+import {
+  listSubTestPlans,
+  ListSubTestPlansSchema,
+} from "./testmanagement-utils/list-sub-testplans.js";
+
+import {
+  getSubTestPlan,
+  GetSubTestPlanSchema,
+} from "./testmanagement-utils/get-sub-testplan.js";
+
 import { BrowserStackConfig } from "../lib/types.js";
 
 //TODO: Moving the traceMCP and catch block to the parent(server) function
@@ -547,6 +557,77 @@ export async function getTestPlanTool(
 }
 
 /**
+ * Lists sub-test-plans under a parent test plan.
+ */
+export async function listSubTestPlansTool(
+  args: z.infer<typeof ListSubTestPlansSchema>,
+  config: BrowserStackConfig,
+  server: McpServer,
+): Promise<CallToolResult> {
+  try {
+    trackMCP(
+      "listSubTestPlans",
+      server.server.getClientVersion()!,
+      undefined,
+      config,
+    );
+    return await listSubTestPlans(args, config);
+  } catch (err) {
+    logger.error("Failed to list sub-test-plans: %s", err);
+    trackMCP(
+      "listSubTestPlans",
+      server.server.getClientVersion()!,
+      err,
+      config,
+    );
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to list sub-test-plans: ${
+            err instanceof Error ? err.message : "Unknown error"
+          }. Please open an issue on GitHub if the problem persists`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Fetches a sub-test-plan by identifier, with its linked runs and a derived status summary.
+ */
+export async function getSubTestPlanTool(
+  args: z.infer<typeof GetSubTestPlanSchema>,
+  config: BrowserStackConfig,
+  server: McpServer,
+): Promise<CallToolResult> {
+  try {
+    trackMCP(
+      "getSubTestPlan",
+      server.server.getClientVersion()!,
+      undefined,
+      config,
+    );
+    return await getSubTestPlan(args, config);
+  } catch (err) {
+    logger.error("Failed to fetch sub-test-plan: %s", err);
+    trackMCP("getSubTestPlan", server.server.getClientVersion()!, err, config);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to fetch sub-test-plan: ${
+            err instanceof Error ? err.message : "Unknown error"
+          }. Please open an issue on GitHub if the problem persists`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
  * Registers both project/folder and test-case tools.
  */
 export default function addTestManagementTools(
@@ -652,6 +733,20 @@ export default function addTestManagementTools(
     "Fetch a test plan by identifier (TP-*) from BrowserStack Test Management. Returns plan metadata, the full list of linked test runs, total test-case count across runs, and a status summary — suitable for generating test documentation or QA status reports.",
     GetTestPlanSchema.shape,
     (args) => getTestPlanTool(args, config, server),
+  );
+
+  tools.listSubTestPlans = server.tool(
+    "listSubTestPlans",
+    "List sub-test-plans under a parent test plan (TP-*) in a Test Management project. Supports pagination.",
+    ListSubTestPlansSchema.shape,
+    (args) => listSubTestPlansTool(args, config, server),
+  );
+
+  tools.getSubTestPlan = server.tool(
+    "getSubTestPlan",
+    "Fetch a sub-test-plan (STP-*) under a parent plan (TP-*). Returns metadata and linked test runs.",
+    GetSubTestPlanSchema.shape,
+    (args) => getSubTestPlanTool(args, config, server),
   );
 
   return tools;

--- a/tests/tools/testmanagement.test.ts
+++ b/tests/tools/testmanagement.test.ts
@@ -11,6 +11,8 @@ import {
   listTestCasesTool,
   listTestPlansTool,
   getTestPlanTool,
+  listSubTestPlansTool,
+  getSubTestPlanTool,
 } from '../../src/tools/testmanagement';
 import addTestManagementTools from '../../src/tools/testmanagement';
 import { createProjectOrFolder } from '../../src/tools/testmanagement-utils/create-project-folder';
@@ -22,10 +24,12 @@ import { listTestRuns } from '../../src/tools/testmanagement-utils/list-testruns
 import { updateTestRun } from '../../src/tools/testmanagement-utils/update-testrun';
 import { listTestPlans } from '../../src/tools/testmanagement-utils/list-testplans';
 import { getTestPlan } from '../../src/tools/testmanagement-utils/get-testplan';
+import { listSubTestPlans } from '../../src/tools/testmanagement-utils/list-sub-testplans';
+import { getSubTestPlan } from '../../src/tools/testmanagement-utils/get-sub-testplan';
 import { createTestCasesFromFile } from '../../src/tools/testmanagement-utils/testcase-from-file';
 import { createLCASteps } from '../../src/tools/testmanagement-utils/create-lca-steps';
 import axios from 'axios';
-import { beforeEach, it, expect, describe, Mocked} from 'vitest';
+import { beforeAll, beforeEach, it, expect, describe, Mocked} from 'vitest';
 import { vi, Mock } from 'vitest';
 import { signedUrlMap } from '../../src/lib/inmemory-store';
 import { uploadFile } from '../../src/tools/testmanagement-utils/upload-file';
@@ -164,6 +168,30 @@ vi.mock('../../src/tools/testmanagement-utils/get-testplan', () => ({
     parse: (args: any) => args,
     shape: {},
   },
+}));
+vi.mock('../../src/tools/testmanagement-utils/list-sub-testplans', () => ({
+  listSubTestPlans: vi.fn(),
+  ListSubTestPlansSchema: {
+    parse: (args: any) => args,
+    shape: {},
+  },
+}));
+vi.mock('../../src/tools/testmanagement-utils/get-sub-testplan', () => ({
+  getSubTestPlan: vi.fn(),
+  GetSubTestPlanSchema: {
+    parse: (args: any) => args,
+    shape: {},
+  },
+}));
+// Mocked for the util-level fail-soft test on getSubTestPlan (which calls
+// vi.importActual to reach the real util). Other tests in this file mock their
+// utils at the module level, so apiClient and tm-base-url never get reached
+// through real code paths today — adding these mocks is safe.
+vi.mock('../../src/lib/apiClient', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn() },
+}));
+vi.mock('../../src/lib/tm-base-url', () => ({
+  getTMBaseURL: vi.fn(async () => 'https://test-management.browserstack.com'),
 }));
 
 
@@ -788,5 +816,218 @@ describe('getTestPlanTool', () => {
     const result = await getTestPlanTool(args, mockConfig, mockServer);
     expect(result.isError).toBe(true);
     expect(result.content?.[0]?.text).toContain('Failed to fetch test plan: Not Found');
+  });
+});
+
+describe('listSubTestPlansTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const args = {
+    project_identifier: 'PR-1',
+    parent_test_plan_identifier: 'TP-45',
+  };
+  const mockSubPlans = [
+    { identifier: 'STP-194', name: 'Sprint 1', active_state: 'active', parent_plan_id: 'TP-45', tags: ['sprint'] },
+    { identifier: 'STP-195', name: 'Sprint 2', active_state: 'active', parent_plan_id: 'TP-45' },
+  ];
+
+  it('should return summary and raw JSON on success', async () => {
+    (listSubTestPlans as Mock).mockResolvedValue({
+      content: [
+        { type: 'text', text: 'Found 2 sub-test-plan(s) under TP-45 in project PR-1:\n\n• STP-194: Sprint 1 [active]' },
+        { type: 'text', text: JSON.stringify(mockSubPlans, null, 2) },
+      ],
+      isError: false,
+    });
+    const result = await listSubTestPlansTool(args, mockConfig, mockServer);
+    expect(result.isError).toBe(false);
+    expect(result.content?.[0]?.text).toContain('Found 2 sub-test-plan(s)');
+    expect(result.content?.[1]?.text).toBe(JSON.stringify(mockSubPlans, null, 2));
+  });
+
+  it('should handle errors', async () => {
+    (listSubTestPlans as Mock).mockRejectedValue(new Error('Network Error'));
+    const result = await listSubTestPlansTool(args, mockConfig, mockServer);
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain('Failed to list sub-test-plans: Network Error');
+  });
+});
+
+describe('getSubTestPlanTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const args = {
+    project_identifier: 'PR-1',
+    parent_test_plan_identifier: 'TP-45',
+    sub_test_plan_identifier: 'STP-194',
+  };
+
+  it('should return sub-plan details, linked runs and status summary on success', async () => {
+    const payload = {
+      sub_test_plan: {
+        identifier: 'STP-194',
+        name: 'Sprint 1',
+        active_state: 'active',
+        parent_plan_id: 'TP-45',
+        tags: ['sprint', 'regression'],
+      },
+      linked_test_runs: [
+        { identifier: 'TR-1', name: 'Run One', run_state: 'new_run', test_cases_count: 8 },
+      ],
+      status_summary: { new_run: 1 },
+      total_test_cases: 8,
+    };
+    (getSubTestPlan as Mock).mockResolvedValue({
+      content: [
+        { type: 'text', text: 'Sub-Test-Plan STP-194: Sprint 1\nParent plan: TP-45\nStatus: active\nTotal test cases across runs: 8' },
+        { type: 'text', text: JSON.stringify(payload, null, 2) },
+      ],
+      isError: false,
+    });
+    const result = await getSubTestPlanTool(args, mockConfig, mockServer);
+    expect(result.isError).toBe(false);
+    expect(result.content?.[0]?.text).toContain('STP-194');
+    expect(result.content?.[0]?.text).toContain('Parent plan: TP-45');
+    expect(result.content?.[1]?.text).toBe(JSON.stringify(payload, null, 2));
+  });
+
+  it('should handle errors', async () => {
+    (getSubTestPlan as Mock).mockRejectedValue(new Error('Not Found'));
+    const result = await getSubTestPlanTool(args, mockConfig, mockServer);
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain('Failed to fetch sub-test-plan: Not Found');
+  });
+});
+
+// Util-level test for the riskier fail-soft enrichment branch in getSubTestPlan.
+// Uses vi.importActual to reach the real util (the top-level vi.mock above
+// otherwise replaces it). vi.mock is statically hoisted, so a top-level import
+// is unusable — importActual inside beforeAll is the only viable path.
+describe('getSubTestPlan util — fail-soft enrichment', () => {
+  let getSubTestPlanReal: typeof import('../../src/tools/testmanagement-utils/get-sub-testplan').getSubTestPlan;
+  let apiClientMock: typeof import('../../src/lib/apiClient').apiClient;
+
+  beforeAll(async () => {
+    const actual = await vi.importActual<typeof import('../../src/tools/testmanagement-utils/get-sub-testplan')>(
+      '../../src/tools/testmanagement-utils/get-sub-testplan'
+    );
+    getSubTestPlanReal = actual.getSubTestPlan;
+    const apiClientModule = await import('../../src/lib/apiClient');
+    apiClientMock = apiClientModule.apiClient;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const baseSubPlan = {
+    identifier: 'STP-194',
+    name: 'Sprint 1',
+    active_state: 'active',
+    parent_plan_id: 'TP-45',
+    test_runs_count: { active: 0, closed: 0 },
+    tags: [],
+  };
+
+  it('returns sub-plan metadata + "No test runs linked" when enrichment rejects (does NOT flip isError); calls the link URL verbatim', async () => {
+    const subPlan = {
+      ...baseSubPlan,
+      links: { test_runs: '/api/v2/projects/PR-1/test-plans/STP-194/test-runs' },
+    };
+    (apiClientMock.get as Mock)
+      .mockResolvedValueOnce({ data: { success: true, sub_test_plan: subPlan } })
+      .mockRejectedValueOnce(new Error('Network Error'));
+
+    const result = await getSubTestPlanReal(
+      {
+        project_identifier: 'PR-1',
+        parent_test_plan_identifier: 'TP-45',
+        sub_test_plan_identifier: 'STP-194',
+      },
+      mockConfig as any,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content?.[0]?.text).toContain('STP-194');
+    expect(result.content?.[0]?.text).toContain('Parent plan: TP-45');
+    expect(result.content?.[0]?.text).toContain('No test runs linked to this sub-plan');
+
+    // Verify the enrichment call hit the link URL verbatim (joined under tmBaseUrl),
+    // not a re-constructed path. This protects the URL composition contract.
+    const enrichmentCall = (apiClientMock.get as Mock).mock.calls[1][0];
+    expect(enrichmentCall.url).toBe(
+      'https://test-management.browserstack.com/api/v2/projects/PR-1/test-plans/STP-194/test-runs',
+    );
+  });
+
+  it('returns sub-plan metadata + "No test runs linked" when enrichment returns success:false (non-throwing degradation)', async () => {
+    const subPlan = {
+      ...baseSubPlan,
+      links: { test_runs: '/api/v2/projects/PR-1/test-plans/STP-194/test-runs' },
+    };
+    (apiClientMock.get as Mock)
+      .mockResolvedValueOnce({ data: { success: true, sub_test_plan: subPlan } })
+      .mockResolvedValueOnce({ data: { success: false, error: 'rate limited' } });
+
+    const result = await getSubTestPlanReal(
+      {
+        project_identifier: 'PR-1',
+        parent_test_plan_identifier: 'TP-45',
+        sub_test_plan_identifier: 'STP-194',
+      },
+      mockConfig as any,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content?.[0]?.text).toContain('STP-194');
+    expect(result.content?.[0]?.text).toContain('No test runs linked to this sub-plan');
+  });
+
+  it('falls back to constructed URL when links.test_runs is an absolute URL with a mismatched host (SSRF guard)', async () => {
+    const subPlan = {
+      ...baseSubPlan,
+      links: { test_runs: 'http://169.254.169.254/latest/meta-data/' },
+    };
+    (apiClientMock.get as Mock)
+      .mockResolvedValueOnce({ data: { success: true, sub_test_plan: subPlan } })
+      .mockRejectedValueOnce(new Error('Network Error'));
+
+    await getSubTestPlanReal(
+      {
+        project_identifier: 'PR-1',
+        parent_test_plan_identifier: 'TP-45',
+        sub_test_plan_identifier: 'STP-194',
+      },
+      mockConfig as any,
+    );
+
+    // The off-host link must NOT be called; the constructed fallback must be used instead.
+    const enrichmentCall = (apiClientMock.get as Mock).mock.calls[1][0];
+    expect(enrichmentCall.url).not.toContain('169.254.169.254');
+    expect(enrichmentCall.url).toBe(
+      'https://test-management.browserstack.com/api/v2/projects/PR-1/test-plans/STP-194/test-runs',
+    );
+  });
+
+  it('returns isError on primary fetch failure', async () => {
+    (apiClientMock.get as Mock).mockResolvedValueOnce({
+      data: { success: false, message: 'Sub-plan not found' },
+    });
+
+    const result = await getSubTestPlanReal(
+      {
+        project_identifier: 'PR-1',
+        parent_test_plan_identifier: 'TP-45',
+        sub_test_plan_identifier: 'STP-999',
+      },
+      mockConfig as any,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain('Failed to fetch sub-test-plan');
   });
 });


### PR DESCRIPTION
## Summary

Adds two new MCP tools that surface BrowserStack Test Management's v2 sub-test-plan endpoints, mirroring the existing `listTestPlans` / `getTestPlan` pair. The existing tools are not modified.

- **`listSubTestPlans(project_identifier, parent_test_plan_identifier, p?)`** → `GET /api/v2/projects/{PR}/test-plans/{TP}/sub-test-plans`
- **`getSubTestPlan(project_identifier, parent_test_plan_identifier, sub_test_plan_identifier)`** → `GET /api/v2/projects/{PR}/test-plans/{TP}/sub-test-plans/{STP}` plus best-effort linked-test-runs enrichment via the response's `links.test_runs` field.

## Key implementation decisions

- **Two new tools rather than extending the existing pair.** Sub-plans use a distinct identifier namespace (`STP-*`), a different response root key (`sub_test_plan`), and expose extra fields (`tags`, `issues`, `parent_plan_id`). Layering this behind an optional param on the existing tools would have made `test_plan_identifier` mode-dependent (TP-* vs STP-*) — a Zod-unenforceable foot-gun.
- **Fail-soft enrichment via inner `try/catch`.** `getSubTestPlan` wraps the secondary `apiClient.get` for linked runs in its own `try/catch` that coerces any failure (thrown OR `success: false`) to an empty runs list. The primary response's `isError` is never flipped by an enrichment failure. This deviates from `get-testplan.ts`'s single-outer-catch shape (which would have flipped `isError` on a thrown enrichment).
- **SSRF host-parity guard on `links.test_runs`.** When the API returns an absolute URL in `links.test_runs`, the host must match the TM base URL host; otherwise the constructed fallback is used. Relative paths are joined under the TM base URL directly.
- **v2 endpoints only.** The web UI's v1 endpoint with `q[parent_plan_id]` and `ignore_type=true` is the app's internal shortcut, not the canonical public API.

## Scope (deliberate)

**In:** `list` and `get` for sub-test-plans, plus tool prompts within the ≤120-char target.

**Out:** create / update / delete sub-plan tools (the v2 API exposes them; deferred for follow-up). No changes to `listTestPlans` / `getTestPlan`. No refactor of the duplicated Basic-auth header construction across the four test-plan tools.

## Testing

- 4 wrapper-layer tests (success + error per tool) in `tests/tools/testmanagement.test.ts`.
- 4 util-level tests for `getSubTestPlan`'s fail-soft branches:
  - enrichment rejects with an error → returns sub-plan + "No test runs linked", `isError` not set; asserts the enrichment URL called (verbatim from `links.test_runs`).
  - enrichment returns `{ success: false }` → same graceful degradation, non-throwing.
  - `links.test_runs` is an absolute URL with a mismatched host (SSRF attempt, e.g. `169.254.169.254`) → falls back to the constructed URL, off-host link never called.
  - primary fetch returns `success: false` → `isError: true` with the API payload.
- Full local build green: `npm run build` (lint + format + 155 tests + tsc) passes.

## Live verification (MCP Inspector CLI vs production TM API)

Both tools executed end-to-end against the real BrowserStack TM API via `@modelcontextprotocol/inspector --cli`, hitting a real parent plan (`TP-3443`) and its sub-plan (`STP-464`) in project `PR-67646`.

**`listSubTestPlans`**

```
Args: { project_identifier: "PR-67646", parent_test_plan_identifier: "TP-3443" }

Found 1 sub-test-plan(s) under TP-3443 in project PR-67646:
• STP-464: Sub Test Plan - 25/05/2026 [active] — 0 active / 0 closed run(s)
```

**`getSubTestPlan`**

```
Args: { project_identifier: "PR-67646", parent_test_plan_identifier: "TP-3443",
        sub_test_plan_identifier: "STP-464" }

Sub-Test-Plan STP-464: Sub Test Plan - 25/05/2026
Parent plan: TP-3443
Status: active
Linked runs: 0 (plan counts — active 0 / closed 0)
Total test cases across runs: 0

No test runs linked to this sub-plan.
```

**Behavior confirmed against live API:**
- GET response includes `links.test_runs` exactly as the v2 docs sample showed:
  `"/api/v2/projects/PR-67646/test-plans/STP-464/test-runs"` — the **flat URL shape is correct** (not nested under the parent), confirming the constructed-fallback shape in `resolveEnrichmentUrl`.
- Enrichment call fires against `links.test_runs` (preferred path); returns `success: true` with `test_runs: []` for this sub-plan — renderer correctly produces "No test runs linked to this sub-plan."
- Conditional date line suppressed when both dates are `null` (header rendering working).
- Sub-plan-specific fields (`tags`, `issues`, `parent_plan_id`, `sub_plans_count`) surface in the JSON block as designed.
- List vs GET response shape note: the v2 list response uses `urls` (only `self`); the GET response carries both `urls` and `links` — our code reads `links.test_runs` from GET only, correctly aligned.

## Multi-tenant safety

Both tools are stateless reads — no module-level mutable state, no imports from `src/lib/inmemory-store.ts`. No coordination with the remote MCP wrapper's `INITIALLY_DISABLED_TOOLS` list is required.

## Post-Deploy Monitoring & Validation

- **Logs:** filter for `mcp_tool=listSubTestPlans` and `mcp_tool=getSubTestPlan` in the standard MCP instrumentation pipeline. `trackMCP` is wired for both success and error paths on each wrapper, so error rates should appear in the same dashboard as the existing test-plan tools.
- **Expected healthy signals:** error rate ≤ that of `listTestPlans` / `getTestPlan`; latency comparable (one extra HTTP call on `getSubTestPlan` for the enrichment).
- **Failure signals to watch:**
  - Spike in `getSubTestPlan` errors mentioning "Failed to fetch sub-test-plan" — indicates the primary endpoint shape may have drifted.
  - Silently-empty linked-runs responses for sub-plans known to have runs — would indicate the enrichment URL is wrong against real data (the brainstorm's Deferred-to-Implementation item; fail-soft absorbs the failure, so this is a data-quality regression, not an error rate spike).
- **Rollback trigger:** if either tool's error rate exceeds 5× baseline for the existing test-plan tools sustained for 1h, disable via the remote wrapper's tool allowlist; no schema migration to reverse.
- **Validation window:** 24h post-deploy. Owner: same on-call rotation as Test Management tools.
