### PR TITLE
chore: bump version to 1.2.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserstack/mcp-server",
-      "version": "1.2.17",
+      "version": "1.2.18",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "BrowserStack's Official MCP Server",
   "mcpName": "io.github.browserstack/mcp-server",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@browserstack/mcp-server",
-      "version": "1.2.17",
+      "version": "1.2.18",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Bumps `@browserstack/mcp-server` from 1.2.17 → 1.2.18 in `package.json`, `package-lock.json`, and `server.json` (nested `packages[].version`).
- Patch release covering changes merged since 1.2.17 (sub test plan tools, selfheal session/prompt fixes, accessibility password redaction, etc.).

## Test plan
- [ ] CI passes (`npm run build` — lint + format + test + tsc).
- [ ] After merge, maintainer triggers the `Release New Version` workflow to publish v1.2.18 to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)