### PR TITLE
fix: replace literal BrowserStack access key with placeholder in SDK / yml tool output

### DIFF
--- a/src/tools/sdk-utils/bstack/commands.ts
+++ b/src/tools/sdk-utils/bstack/commands.ts
@@ -13,19 +13,20 @@ const JAVA_FRAMEWORK_MAP: Record<string, string> = {
   cucumber: "cucumber-testng",
 } as const;
 
+// The literal access key is never echoed into tool output; users substitute
+// this placeholder locally. See PMAA-100 security review.
+const ACCESS_KEY_PLACEHOLDER = "<your BrowserStack access key>";
+
 // Template for Node.js SDK setup instructions
-const NODEJS_SDK_INSTRUCTIONS = (
-  username: string,
-  accessKey: string,
-): string => `---STEP---
+const NODEJS_SDK_INSTRUCTIONS = (username: string): string => `---STEP---
 Install BrowserStack Node SDK using command:
 \`\`\`bash
 npm i -D browserstack-node-sdk@latest
 \`\`\`
 ---STEP---
-Run the following command to setup browserstack sdk:
+Run the following command to setup browserstack sdk (replace the placeholder with your BrowserStack access key):
 \`\`\`bash
-npx setup --username ${username} --key ${accessKey}
+npx setup --username ${username} --key "${ACCESS_KEY_PLACEHOLDER}"
 \`\`\``;
 
 // Template for Gradle setup instructions (platform-independent)
@@ -44,7 +45,6 @@ const GRADLE_SETUP_INSTRUCTIONS = `
 // Generates Maven archetype command for Windows platform
 function getMavenCommandForWindows(
   username: string,
-  accessKey: string,
   mavenFramework: string,
 ): string {
   return (
@@ -56,7 +56,7 @@ function getMavenCommandForWindows(
     `-DartifactId="${MAVEN_ARCHETYPE_ARTIFACT_ID}" ` +
     `-Dversion="${MAVEN_ARCHETYPE_VERSION}" ` +
     `-DBROWSERSTACK_USERNAME="${username}" ` +
-    `-DBROWSERSTACK_ACCESS_KEY="${accessKey}" ` +
+    `-DBROWSERSTACK_ACCESS_KEY="${ACCESS_KEY_PLACEHOLDER}" ` +
     `-DBROWSERSTACK_FRAMEWORK="${mavenFramework}"`
   );
 }
@@ -64,30 +64,25 @@ function getMavenCommandForWindows(
 // Generates Maven archetype command for Unix-like platforms (macOS/Linux)
 function getMavenCommandForUnix(
   username: string,
-  accessKey: string,
   mavenFramework: string,
 ): string {
   return `mvn archetype:generate -B -DarchetypeGroupId=${MAVEN_ARCHETYPE_GROUP_ID} \\
 -DarchetypeArtifactId=${MAVEN_ARCHETYPE_ARTIFACT_ID} -DarchetypeVersion=${MAVEN_ARCHETYPE_VERSION} \\
 -DgroupId=${MAVEN_ARCHETYPE_GROUP_ID} -DartifactId=${MAVEN_ARCHETYPE_ARTIFACT_ID} -Dversion=${MAVEN_ARCHETYPE_VERSION} \\
 -DBROWSERSTACK_USERNAME="${username}" \\
--DBROWSERSTACK_ACCESS_KEY="${accessKey}" \\
+-DBROWSERSTACK_ACCESS_KEY="${ACCESS_KEY_PLACEHOLDER}" \\
 -DBROWSERSTACK_FRAMEWORK="${mavenFramework}"`;
 }
 
 // Generates Java SDK setup instructions with Maven/Gradle options
-function getJavaSDKInstructions(
-  framework: string,
-  username: string,
-  accessKey: string,
-): string {
+function getJavaSDKInstructions(framework: string, username: string): string {
   const mavenFramework = getJavaFrameworkForMaven(framework);
   const isWindows = process.platform === "win32";
   const platformLabel = isWindows ? "Windows" : "macOS/Linux";
 
   const mavenCommand = isWindows
-    ? getMavenCommandForWindows(username, accessKey, mavenFramework)
-    : getMavenCommandForUnix(username, accessKey, mavenFramework);
+    ? getMavenCommandForWindows(username, mavenFramework)
+    : getMavenCommandForUnix(username, mavenFramework);
 
   return `---STEP---
 Install BrowserStack Java SDK
@@ -105,14 +100,13 @@ export function getSDKPrefixCommand(
   language: SDKSupportedLanguage,
   framework: string,
   username: string,
-  accessKey: string,
 ): string {
   switch (language) {
     case "nodejs":
-      return NODEJS_SDK_INSTRUCTIONS(username, accessKey);
+      return NODEJS_SDK_INSTRUCTIONS(username);
 
     case "java":
-      return getJavaSDKInstructions(framework, username, accessKey);
+      return getJavaSDKInstructions(framework, username);
 
     default:
       return "";

--- a/src/tools/sdk-utils/bstack/configUtils.ts
+++ b/src/tools/sdk-utils/bstack/configUtils.ts
@@ -16,7 +16,7 @@ export function generateBrowserStackYMLInstructions(
 
   // Get credentials from config
   const authString = getBrowserStackAuth(browserStackConfig);
-  const [username, accessKey] = authString.split(":");
+  const [username] = authString.split(":");
 
   // Generate platform configurations using the utility function
   const platformConfigs = generatePlatformConfigs(config);
@@ -32,7 +32,7 @@ export function generateBrowserStackYMLInstructions(
 # ======================
 
 userName: ${username}
-accessKey: ${accessKey}
+accessKey: "<your BrowserStack access key>"
 
 # TODO: Replace these sample values with your actual project details
 projectName: ${projectName}

--- a/src/tools/sdk-utils/bstack/sdkHandler.ts
+++ b/src/tools/sdk-utils/bstack/sdkHandler.ts
@@ -92,7 +92,6 @@ export async function runBstackSDKOnly(
     input.detectedLanguage as SDKSupportedLanguage,
     input.detectedTestingFramework as SDKSupportedTestingFramework,
     username,
-    accessKey,
   );
 
   if (sdkSetupCommand) {

--- a/src/tools/sdk-utils/percy-bstack/handler.ts
+++ b/src/tools/sdk-utils/percy-bstack/handler.ts
@@ -95,7 +95,6 @@ export function runPercyWithBrowserstackSDK(
     input.detectedLanguage as SDKSupportedLanguage,
     input.detectedTestingFramework as SDKSupportedTestingFramework,
     username,
-    accessKey,
   );
 
   if (sdkSetupCommand) {

--- a/tests/tools/sdk-utils-commands.test.ts
+++ b/tests/tools/sdk-utils-commands.test.ts
@@ -12,37 +12,39 @@ describe("getSDKPrefixCommand", () => {
 
   beforeEach(() => {
     // Guard: ensure these env vars never leak into the rendered command.
-    // The fix forwards `username` / `accessKey` parameters; reading process.env
-    // would silently return undefined or a stale value in remote (multi-tenant) mode.
+    // The fix forwards `username` from the parameter; the access key is no
+    // longer accepted as a parameter and is never echoed.
     delete process.env.BROWSERSTACK_USERNAME;
     delete process.env.BROWSERSTACK_ACCESS_KEY;
   });
 
-  it("nodejs: embeds passed username/accessKey, never reads process.env", () => {
-    const out = getSDKPrefixCommand("nodejs", "testng", "u-from-config", "k-from-config");
+  const PLACEHOLDER = "<your BrowserStack access key>";
+
+  it("nodejs: embeds passed username and emits placeholder for accessKey", () => {
+    const out = getSDKPrefixCommand("nodejs", "testng", "u-from-config");
     expect(out).toContain("--username u-from-config");
-    expect(out).toContain("--key k-from-config");
+    expect(out).toContain(PLACEHOLDER);
     expect(out).not.toContain("undefined");
     expect(out).not.toContain("process.env");
   });
 
-  it("java/unix: Maven command uses passed username/accessKey", () => {
+  it("java/unix: Maven command uses passed username and emits placeholder for accessKey", () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
-    const out = getSDKPrefixCommand("java", "testng", "u-from-config", "k-from-config");
+    const out = getSDKPrefixCommand("java", "testng", "u-from-config");
     expect(out).toContain('-DBROWSERSTACK_USERNAME="u-from-config"');
-    expect(out).toContain('-DBROWSERSTACK_ACCESS_KEY="k-from-config"');
+    expect(out).toContain(`-DBROWSERSTACK_ACCESS_KEY="${PLACEHOLDER}"`);
     expect(out).not.toContain("undefined");
     expect(out).not.toContain("process.env");
   });
 
-  it("java/windows: Maven command uses passed username/accessKey (regression)", () => {
+  it("java/windows: Maven command uses passed username and emits placeholder for accessKey (regression)", () => {
     // Regression for a bug where the Windows branch read process.env.BROWSERSTACK_*
     // while the Unix branch correctly took params. In remote mode this leaked the
     // string "undefined" into the Maven command shown to the user.
     Object.defineProperty(process, "platform", { value: "win32" });
-    const out = getSDKPrefixCommand("java", "testng", "u-from-config", "k-from-config");
+    const out = getSDKPrefixCommand("java", "testng", "u-from-config");
     expect(out).toContain('-DBROWSERSTACK_USERNAME="u-from-config"');
-    expect(out).toContain('-DBROWSERSTACK_ACCESS_KEY="k-from-config"');
+    expect(out).toContain(`-DBROWSERSTACK_ACCESS_KEY="${PLACEHOLDER}"`);
     expect(out).not.toContain("undefined");
     expect(out).not.toContain("process.env");
   });


### PR DESCRIPTION
## What this PR does 
  Stops the BrowserStack SDK setup instructions and `browserstack.yml` generator from emitting the literal
  `BROWSERSTACK_ACCESS_KEY` into MCP tool output. Output now contains a `<your BrowserStack access key>`
  placeholder; users substitute their key locally.
  
  ## Why
  Same prompt-injection exfil class as PMAA-100's Percy token leak: anything in MCP tool response text can be
  recovered from LLM transcripts, shared sessions, or compromised assistant sessions. The access key is
  user-supplied (lower severity than the server-fetched Percy token) but the path is identical.
 
  Flagged during PMAA-100 security review as the "Adjacent concern" —
  explicitly framed as out-of-scope for PMAA-100 with a recommendation to open a follow-up audit ticket. **This
   is that follow-up.**

  ## Changes 
  - `src/tools/sdk-utils/bstack/commands.ts` — `getSDKPrefixCommand` (and its internal helpers) no longer take
  an `accessKey` parameter. Output uses a shared `ACCESS_KEY_PLACEHOLDER` constant.
  - `src/tools/sdk-utils/bstack/configUtils.ts` — `generateBrowserStackYMLInstructions` emits `accessKey:
  "<your BrowserStack access key>"` in the rendered `browserstack.yml`.
  - `src/tools/sdk-utils/percy-bstack/handler.ts`, `src/tools/sdk-utils/bstack/sdkHandler.ts` — callers updated
   to drop the now-removed `accessKey` argument.
  - `tests/tools/sdk-utils-commands.test.ts` — assertions inverted to pin the new contract: the placeholder
  must appear; the access key must not.
 
  ## Behavioural change
  Maven and Node.js setup commands in tool output now contain the placeholder string where the literal key used
   to appear. Users substitute their key before running — matches the pattern used for the Percy token
  (#288).
  
  ## Out of scope (worth a separate audit if not already tracked)
  Other `${accessKey}` interpolation sites that this PR doesn't touch:
  - `src/tools/sdk-utils/bstack/constants.ts` — 6 sites
  - `src/tools/appautomate-utils/appium-sdk/languages/java.ts` — 2 sites
  - `src/tools/appautomate-utils/appium-sdk/languages/nodejs.ts` — 1 site

  ## Verification
  - `npm run build` → lint, format, **171 tests pass**, tsc clean.
  - `getSDKPrefixCommand` is not imported anywhere outside `src/tools/sdk-utils/bstack/` and
  `src/tools/sdk-utils/percy-bstack/` (verified via `grep -rn`).