### PR TITLE
fix: enable strict TLS validation when CA cert is configured

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -78,7 +78,6 @@ function getAxiosAgent(): AxiosRequestConfig["httpsAgent"] | undefined {
         host: proxyHost,
         port: Number(proxyPort),
         ca,
-        rejectUnauthorized: false, // Set to true if you want strict SSL
       });
     } else {
       // Proxy only
@@ -88,7 +87,6 @@ function getAxiosAgent(): AxiosRequestConfig["httpsAgent"] | undefined {
     // CA only
     return new https.Agent({
       ca: fs.readFileSync(caCertPath),
-      rejectUnauthorized: false, // Set to true for strict SSL
     });
   }
   // Default agent (no proxy, no CA)


### PR DESCRIPTION
## What this PR does
  Removes `rejectUnauthorized: false` from both HTTPS agents in `src/lib/apiClient.ts` (`HttpsProxyAgent` +
  `https.Agent` paths). TLS validation now follows Node's default (strict). The user-supplied CA cert is still
   loaded; that's what makes corporate proxy chains validate.

  ## Why
  When `BROWSERSTACK_LOCAL_OPTION_USECACERTIFICATE` was set, the previous code accepted *any* TLS certificate
  — MITM-trivial for every BrowserStack API call, exposing credentials and traffic to any network-positioned
  attacker. 