### PR TITLE
fix(ci): harden workflows

### DIFF
--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     if: github.event.pull_request.base.ref == 'main' && github.event.review.state == 'approved'

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -31,19 +31,8 @@ jobs:
         run: npm run build --if-present
 
       - name: Install MCP Publisher
-        # Pinned to v1.3.3 linux_amd64. To upgrade: bump VERSION and SHA256
-        # (capture via: shasum -a 256 mcp-publisher_linux_amd64.tar.gz, or use
-        # registry_<ver>_checksums.txt from the release).
-        env:
-          VERSION: v1.3.3
-          SHA256: 1113b9d6bf59b000966c4f17752cf87b51db03dcc5482721421fd843ce3bf048
         run: |
-          curl -fsSL -o mcp-publisher.tar.gz \
-            "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.tar.gz"
-          echo "${SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
-          tar xzf mcp-publisher.tar.gz mcp-publisher
-          rm mcp-publisher.tar.gz
-    
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.3.3/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher    
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc
 

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -31,8 +31,18 @@ jobs:
         run: npm run build --if-present
 
       - name: Install MCP Publisher
+        # Pinned to v1.3.3 linux_amd64. To upgrade: bump VERSION and SHA256
+        # (capture via: shasum -a 256 mcp-publisher_linux_amd64.tar.gz, or use
+        # registry_<ver>_checksums.txt from the release).
+        env:
+          VERSION: v1.3.3
+          SHA256: 1113b9d6bf59b000966c4f17752cf87b51db03dcc5482721421fd843ce3bf048
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.3.3/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          rm mcp-publisher.tar.gz
     
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:
@@ -99,7 +100,7 @@ jobs:
         run: git push origin ${{ steps.get_version.outputs.version }}
 
       - name: "Publish to NPM"
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
  ## Summary
  Three independent workflow hardening fixes.

  ## Changes

  **1. `mcp-ci.yml` — least-privilege permissions**
  Added top-level `permissions: contents: read`. The CI workflow previously inherited the write-all
  default for `GITHUB_TOKEN`; it only needs to check out the repo and run `npm test`.
  
  **2. `npm-publish.yml` — npm provenance**
  Added `--provenance` to the `npm publish` command and the required `id-token: write` permission.
  Released packages now carry a signed attestation linking the tarball to this workflow run on this
  repo — defends against trojaned releases via a leaked `NPM_TOKEN` or compromised maintainer machine.
   Verifiable by consumers via `npm audit signatures`.

  **3. `mcp-registry-publish.yml` — SHA-verify the `mcp-publisher` binary**
  Replaced `curl … | tar xz` with download → `sha256sum -c` → extract. Pinned to `mcp-publisher`
  v1.3.3 linux_amd64; digest cross-checked against the official `registry_1.3.3_checksums.txt`. 
  Workflow aborts if the downloaded tarball doesn't match.