### PR TITLE
chore: bump version to 1.2.20 in package.json, package-lock.json, and server.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserstack/mcp-server",
-      "version": "1.2.19",
+      "version": "1.2.20",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "BrowserStack's Official MCP Server",
   "mcpName": "io.github.browserstack/mcp-server",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@browserstack/mcp-server",
-      "version": "1.2.19",
+      "version": "1.2.20",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
Bumps the package version from `1.2.19` to `1.2.20` across `package.json`, `package-lock.json`, and `server.json`.

Follows the same pattern as #307.

## Changes
- `package.json`: version → 1.2.20
- `package-lock.json`: root + package version → 1.2.20
- `server.json`: npm package version → 1.2.20

🤖 Generated with [Claude Code](https://claude.com/claude-code)