### PR TITLE
fix: attach auth header on RCA tool MCPInstrumentation events

### DIFF
--- a/src/tools/rca-agent.ts
+++ b/src/tools/rca-agent.ts
@@ -148,7 +148,12 @@ export default function addRCATools(
     FETCH_RCA_PARAMS,
     async (args) => {
       try {
-        trackMCP("fetchRCA", server.server.getClientVersion()!, config);
+        trackMCP(
+          "fetchRCA",
+          server.server.getClientVersion()!,
+          undefined,
+          config,
+        );
         return await fetchRCADataTool(args, config);
       } catch (error) {
         return handleMCPError("fetchRCA", server, config, error);
@@ -162,7 +167,12 @@ export default function addRCATools(
     GET_BUILD_ID_PARAMS,
     async (args) => {
       try {
-        trackMCP("getBuildId", server.server.getClientVersion()!, config);
+        trackMCP(
+          "getBuildId",
+          server.server.getClientVersion()!,
+          undefined,
+          config,
+        );
         return await getBuildIdTool(args, config);
       } catch (error) {
         return handleMCPError("getBuildId", server, config, error);
@@ -176,7 +186,12 @@ export default function addRCATools(
     LIST_TEST_IDS_PARAMS,
     async (args) => {
       try {
-        trackMCP("listTestIds", server.server.getClientVersion()!, config);
+        trackMCP(
+          "listTestIds",
+          server.server.getClientVersion()!,
+          undefined,
+          config,
+        );
         return await listTestIdsTool(args, config);
       } catch (error) {
         return handleMCPError("listTestIds", server, config, error);


### PR DESCRIPTION
Fixes AIMCP-187. fetchRCA/getBuildId/listTestIds pass config into trackMCP's error slot (3-arg call), so no auth header is attached and /sdk/v1/event silently drops the event — these tools log zero usage despite being invoked. Fix passes undefined as the error arg and config as the 4th. Build+tests pass; verified end-to-end (0 events before, success=true after). Full RCA on the ticket.