### PR TITLE
version bump to 1.2.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserstack/mcp-server",
-      "version": "1.2.21",
+      "version": "1.2.22",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "BrowserStack's Official MCP Server",
   "mcpName": "io.github.browserstack/mcp-server",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@browserstack/mcp-server",
-      "version": "1.2.21",
+      "version": "1.2.22",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bumps the package version `1.2.21` → `1.2.22` ahead of release, following the manual version-bump flow (same as #218).

Updates the version in all three files:
- `package.json` → top-level `version`
- `package-lock.json` → top-level `version` and the root package entry (`packages.""`)
- `server.json` → the nested `packages[].version` (the top-level `1.0.0` is the server.json schema version and is left unchanged)

### Release contents
- Test Management: `createTestCase` now supports template selection (internal slug) + multi-select custom fields; `updateTestCase` supports multi-select custom fields (#319).

After merge, a maintainer triggers the `Release New Version` workflow (`workflow_dispatch`), which reads the version from `package.json`, tags `v1.2.22`, publishes to npm, and creates the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)