### PR TITLE
feat(testmanagement): create test cases with a custom template (template_id) + listTestCaseTemplates

### DIFF
--- a/src/tools/testmanagement-utils/create-testcase.ts
+++ b/src/tools/testmanagement-utils/create-testcase.ts
@@ -44,6 +44,7 @@ export interface TestCaseCreateRequest {
   automation_status?: string;
   priority?: string;
   template?: string;
+  template_id?: number;
 }
 
 export interface TestCaseResponse {
@@ -60,6 +61,7 @@ export interface TestCaseResponse {
       }>;
       tags: string[];
       template: string;
+      template_id?: number;
       description: string;
       preconditions: string;
       title: string;
@@ -160,7 +162,13 @@ export const CreateTestCaseSchema = z.object({
     .string()
     .optional()
     .describe(
-      "Template internal slug, e.g. 'test_case_steps' or 'test_case_bdd'. Use the slug, not the display name.",
+      "System template slug only: 'test_case_steps' or 'test_case_bdd'. For a custom template, use template_id instead.",
+    ),
+  template_id: z
+    .number()
+    .optional()
+    .describe(
+      "Numeric ID of a custom template (from listTestCaseTemplates); applies that template. Overrides 'template'.",
     ),
 });
 
@@ -172,6 +180,7 @@ export function sanitizeArgs(args: any) {
   if (cleaned.preconditions === null) delete cleaned.preconditions;
   if (cleaned.automation_status === null) delete cleaned.automation_status;
   if (cleaned.template === null) delete cleaned.template;
+  if (cleaned.template_id === null) delete cleaned.template_id;
 
   if (cleaned.issue_tracker) {
     if (
@@ -218,6 +227,91 @@ async function normalizePriority(
   }
 }
 
+/**
+ * Read a freshly-created test case back to learn which template was actually
+ * applied. The create response does not echo template_id, but the v1 search
+ * endpoint does. Returns undefined on any failure (caller then skips the
+ * verification warning rather than blocking the success path).
+ */
+async function fetchAppliedTemplateId(
+  numericProjectId: string,
+  identifier: string,
+  config: BrowserStackConfig,
+): Promise<number | undefined> {
+  try {
+    const tmBaseUrl = await getTMBaseURL(config);
+    const resp = await apiClient.get({
+      url: `${tmBaseUrl}/api/v1/projects/${encodeURIComponent(
+        numericProjectId,
+      )}/test-cases/search?q%5Bquery%5D=${encodeURIComponent(identifier)}`,
+      headers: {
+        "API-TOKEN": getBrowserStackAuth(config),
+        accept: "application/json, text/plain, */*",
+      },
+    });
+    const cases: Array<{ identifier?: string; template_id?: number }> =
+      resp.data?.test_cases ?? [];
+    const match = cases.find((c) => c.identifier === identifier);
+    return match?.template_id;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The v1 create endpoint (used when a template_id is requested) keys
+ * custom_fields by numeric field id with option *ids* — unlike the v2 endpoint,
+ * which keys by field name with option *values*. Translate the MCP's by-name
+ * shape into v1's by-id shape using the project's form fields. Best-effort:
+ * unknown fields/options pass through unchanged.
+ */
+async function toV1CustomFields(
+  customFields: Record<string, CustomFieldValue>,
+  numericProjectId: string,
+  config: BrowserStackConfig,
+): Promise<Record<string, CustomFieldValue>> {
+  let defs: any[] = [];
+  try {
+    const formFields = await fetchFormFields(numericProjectId, config);
+    defs = Array.isArray(formFields?.custom_fields)
+      ? formFields.custom_fields
+      : [];
+  } catch {
+    return customFields;
+  }
+
+  const byName = new Map<string, any>(defs.map((f) => [f.field_name, f]));
+  const out: Record<string, CustomFieldValue> = {};
+
+  for (const [name, value] of Object.entries(customFields)) {
+    const def = byName.get(name);
+    if (!def) {
+      out[name] = value; // unknown field name — leave as-is
+      continue;
+    }
+    const isOptionField =
+      def.field_type === "field_dropdown" ||
+      def.field_type === "field_multi_dropdown";
+    if (isOptionField) {
+      const optionIdByValue = new Map<string, string | number>();
+      for (const o of (def.option_values ?? []) as Array<{
+        option_value: string | number;
+        id: string | number;
+      }>) {
+        optionIdByValue.set(String(o.option_value), o.id);
+      }
+      const toOptionId = (v: string | number): string | number =>
+        optionIdByValue.get(String(v)) ?? v;
+      out[String(def.id)] = Array.isArray(value)
+        ? value.map(toOptionId)
+        : toOptionId(value as string | number);
+    } else {
+      out[String(def.id)] = value;
+    }
+  }
+  return out;
+}
+
 export async function createTestCase(
   params: TestCaseCreateRequest,
   config: BrowserStackConfig,
@@ -232,23 +326,62 @@ export async function createTestCase(
     );
   }
 
-  const body = { test_case: testCaseParams };
   const authString = getBrowserStackAuth(config);
   const [username, password] = authString.split(":");
 
   try {
     const tmBaseUrl = await getTMBaseURL(config);
-    const response = await apiClient.post({
-      url: `${tmBaseUrl}/api/v2/projects/${encodeURIComponent(
+
+    // The public v2 create endpoint silently drops template_id, so a specific
+    // (custom) template cannot be applied through it. The v1 create endpoint
+    // DOES honour template_id — but it needs the numeric project id, the folder
+    // in the body, API-TOKEN auth, and custom_fields keyed by id. Use v1 only
+    // when a template_id is requested; otherwise keep the proven v2 path so
+    // existing behaviour (incl. custom_fields by name) is unchanged.
+    let request: { url: string; headers: Record<string, string>; body: any };
+    if (testCaseParams.template_id !== undefined) {
+      const numericProjectId = await projectIdentifierToId(
         params.project_identifier,
-      )}/folders/${encodeURIComponent(params.folder_id)}/test-cases`,
-      headers: {
-        "Content-Type": "application/json",
-        Authorization:
-          "Basic " + Buffer.from(`${username}:${password}`).toString("base64"),
-      },
-      body,
-    });
+        config,
+      );
+      const v1TestCase: Record<string, any> = { ...testCaseParams };
+      delete v1TestCase.project_identifier;
+      delete v1TestCase.folder_id;
+      delete v1TestCase.custom_fields;
+      v1TestCase.test_case_folder_id = Number(params.folder_id);
+      if (testCaseParams.custom_fields) {
+        v1TestCase.custom_fields = await toV1CustomFields(
+          testCaseParams.custom_fields,
+          numericProjectId,
+          config,
+        );
+      }
+      request = {
+        url: `${tmBaseUrl}/api/v1/projects/${encodeURIComponent(
+          numericProjectId,
+        )}/test-cases`,
+        headers: {
+          "Content-Type": "application/json",
+          "API-TOKEN": authString,
+        },
+        body: { folder_id: Number(params.folder_id), test_case: v1TestCase },
+      };
+    } else {
+      request = {
+        url: `${tmBaseUrl}/api/v2/projects/${encodeURIComponent(
+          params.project_identifier,
+        )}/folders/${encodeURIComponent(params.folder_id)}/test-cases`,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization:
+            "Basic " +
+            Buffer.from(`${username}:${password}`).toString("base64"),
+        },
+        body: { test_case: testCaseParams },
+      };
+    }
+
+    const response = await apiClient.post(request);
 
     const { data } = response.data;
     if (!data.success) {
@@ -273,9 +406,29 @@ export async function createTestCase(
 
     const content: Array<{ type: "text"; text: string }> = [];
 
+    // A specific custom template is selected by numeric template_id. The create
+    // response does not echo template_id, so read the case back to learn which
+    // template was actually applied and warn on mismatch — the public create
+    // endpoint may silently ignore the requested template.
+    if (params.template_id !== undefined) {
+      const appliedId =
+        tc.template_id !== undefined
+          ? Number(tc.template_id)
+          : await fetchAppliedTemplateId(projectId, tc.identifier, config);
+      if (appliedId !== undefined && appliedId !== Number(params.template_id)) {
+        content.push({
+          type: "text",
+          text: `Warning: requested template_id ${params.template_id} was not applied — the test case uses template_id ${appliedId}. Confirm the id via listTestCaseTemplates and that the template is linked to this project.`,
+        });
+      }
+    }
+
     // The TM API silently ignores an unrecognized template slug and falls back
     // to the default. Surface that instead of letting it pass as success.
+    // Note: the `template` slug only ever selects a SYSTEM template; a custom
+    // template must be selected with template_id.
     if (
+      params.template_id === undefined &&
       params.template &&
       tc.template &&
       String(tc.template).toLowerCase() !==
@@ -283,7 +436,7 @@ export async function createTestCase(
     ) {
       content.push({
         type: "text",
-        text: `Warning: requested template "${params.template}" was not applied — the test case was created with "${tc.template}". BrowserStack expects the template's internal slug (e.g. "test_case_steps", "test_case_bdd") and silently uses the default for unrecognized values.`,
+        text: `Warning: requested template "${params.template}" was not applied — the test case was created with "${tc.template}". The 'template' field accepts only the system slugs "test_case_steps" or "test_case_bdd"; for a custom template pass template_id (see listTestCaseTemplates).`,
       });
     }
 

--- a/src/tools/testmanagement-utils/list-templates.ts
+++ b/src/tools/testmanagement-utils/list-templates.ts
@@ -1,0 +1,114 @@
+import { apiClient } from "../../lib/apiClient.js";
+import { z } from "zod";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { formatAxiosError } from "../../lib/error.js";
+import { getBrowserStackAuth } from "../../lib/get-auth.js";
+import { BrowserStackConfig } from "../../lib/types.js";
+import { getTMBaseURL } from "../../lib/tm-base-url.js";
+
+/**
+ * Schema for listing test-case templates in BrowserStack Test Management.
+ */
+export const ListTemplatesSchema = z.object({
+  name: z
+    .string()
+    .optional()
+    .describe("Case-insensitive substring filter on template name."),
+});
+
+export type ListTemplatesArgs = z.infer<typeof ListTemplatesSchema>;
+
+interface TemplateResponse {
+  id: number;
+  name: string;
+  step_type: string;
+  is_default: boolean;
+  is_system: boolean;
+  enabled: boolean;
+}
+
+/**
+ * Lists test-case templates (group-wide) so callers can resolve a template
+ * name to the numeric template_id.
+ *
+ * Custom templates share a step_type (test_case_steps | test_case_bdd) with the
+ * system templates, so the slug cannot identify them — only the id can. The
+ * list is account-wide; a template must also be linked to the target project to
+ * be usable there.
+ */
+export async function listTemplates(
+  args: ListTemplatesArgs,
+  config: BrowserStackConfig,
+): Promise<CallToolResult> {
+  try {
+    const tmBaseUrl = await getTMBaseURL(config);
+
+    // Verified working with API-TOKEN auth (same surface as form-fields-v2).
+    const resp = await apiClient.get({
+      url: `${tmBaseUrl}/api/v1/admin-v2/settings/templates?entity_type=TestCase&paginated=false`,
+      headers: {
+        "API-TOKEN": getBrowserStackAuth(config),
+        accept: "application/json, text/plain, */*",
+      },
+    });
+
+    let templates: TemplateResponse[] = resp.data?.templates ?? [];
+
+    if (args.name) {
+      const needle = args.name.toLowerCase();
+      templates = templates.filter((t) =>
+        (t.name ?? "").toLowerCase().includes(needle),
+      );
+    }
+
+    if (templates.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: args.name
+              ? `No templates matching "${args.name}".`
+              : "No templates found.",
+          },
+        ],
+      };
+    }
+
+    const summary = templates
+      .map(
+        (t) =>
+          `• [template_id=${t.id}] ${t.name} — step_type=${t.step_type}${
+            t.is_system ? " (system)" : ""
+          }${t.is_default ? " (default)" : ""}${
+            t.enabled === false ? " (disabled)" : ""
+          }`,
+      )
+      .join("\n");
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Found ${templates.length} template(s):\n\n${summary}`,
+        },
+        {
+          type: "text",
+          text: JSON.stringify(
+            templates.map((t) => ({
+              template_id: t.id,
+              name: t.name,
+              step_type: t.step_type,
+              is_system: t.is_system,
+              is_default: t.is_default,
+              enabled: t.enabled,
+            })),
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  } catch (err) {
+    return formatAxiosError(err, "Failed to list templates");
+  }
+}

--- a/src/tools/testmanagement.ts
+++ b/src/tools/testmanagement.ts
@@ -31,6 +31,11 @@ import {
 } from "./testmanagement-utils/list-folders.js";
 
 import {
+  listTemplates,
+  ListTemplatesSchema,
+} from "./testmanagement-utils/list-templates.js";
+
+import {
   CreateTestRunSchema,
   createTestRun,
 } from "./testmanagement-utils/create-testrun.js";
@@ -249,6 +254,43 @@ export async function listFoldersTool(
         {
           type: "text",
           text: `Failed to list folders: ${
+            err instanceof Error ? err.message : "Unknown error"
+          }. Please open an issue on GitHub if the problem persists`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Lists test-case templates so callers can resolve a name to a template_id.
+ */
+export async function listTemplatesTool(
+  args: z.infer<typeof ListTemplatesSchema>,
+  config: BrowserStackConfig,
+  server: McpServer,
+): Promise<CallToolResult> {
+  try {
+    trackMCP(
+      "listTestCaseTemplates",
+      server.server.getClientVersion()!,
+      undefined,
+      config,
+    );
+    return await listTemplates(args, config);
+  } catch (err) {
+    trackMCP(
+      "listTestCaseTemplates",
+      server.server.getClientVersion()!,
+      err,
+      config,
+    );
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to list templates: ${
             err instanceof Error ? err.message : "Unknown error"
           }. Please open an issue on GitHub if the problem persists`,
         },
@@ -669,6 +711,13 @@ export default function addTestManagementTools(
     "List folders in a BrowserStack Test Management project, returning each folder's id and name (plus case counts and sub-folder counts). Pass parent_id to list sub-folders under a specific folder instead of top-level folders.",
     ListFoldersSchema.shape,
     (args) => listFoldersTool(args, config, server),
+  );
+
+  tools.listTestCaseTemplates = server.tool(
+    "listTestCaseTemplates",
+    "List test-case templates with their numeric template_id. Use the id with createTestCase to apply a custom template (the 'template' slug only selects system templates).",
+    ListTemplatesSchema.shape,
+    (args) => listTemplatesTool(args, config, server),
   );
 
   tools.createTestRun = server.tool(

--- a/tests/tools/testmanagement.test.ts
+++ b/tests/tools/testmanagement.test.ts
@@ -1164,7 +1164,7 @@ describe('createTestCase — priority normalization', () => {
   });
 });
 
-// PMAA-131: template slug pass-through + multi-select custom fields.
+// Template slug pass-through + multi-select custom fields.
 // Behaviour verified against the live TM v2 API: the create endpoint keys on
 // the template's internal slug and silently falls back to the default for
 // unrecognized values; multi-select custom fields accept arrays keyed by name.
@@ -1238,9 +1238,142 @@ describe('createTestCase — template & multi-select custom_fields', () => {
     const body = (apiClientMock.post as Mock).mock.calls[0][0].body;
     expect(body.test_case.custom_fields).toEqual({ aaas: ['m40', 'm48'] });
   });
+
+  // A custom template can only be selected by its numeric template_id; the
+  // slug always resolves to a system template (two templates share a step_type).
+  const respWithId = (template_id: number) => ({
+    data: {
+      data: {
+        success: true,
+        test_case: {
+          identifier: 'TC-1',
+          title: 'Sample',
+          folder_id: 1,
+          template: 'test_case_steps',
+          template_id,
+        },
+      },
+    },
+  });
+
+  it('passes template_id through to the request body and does not warn when applied', async () => {
+    (apiClientMock.post as Mock).mockResolvedValueOnce(respWithId(4321));
+
+    const result = await createTestCaseReal(
+      { ...baseArgs, template_id: 4321 },
+      mockConfig as any,
+    );
+
+    const body = (apiClientMock.post as Mock).mock.calls[0][0].body;
+    expect(body.test_case.template_id).toBe(4321);
+    const text = (result.content ?? []).map((c: any) => c.text).join('\n');
+    expect(text).not.toContain('was not applied');
+  });
+
+  it('warns when the API applies a different template_id than requested', async () => {
+    (apiClientMock.post as Mock).mockResolvedValueOnce(respWithId(1));
+
+    const result = await createTestCaseReal(
+      { ...baseArgs, template_id: 4321 },
+      mockConfig as any,
+    );
+
+    const text = (result.content ?? []).map((c: any) => c.text).join('\n');
+    expect(text).toContain('template_id 4321 was not applied');
+    expect(text).toContain('template_id 1');
+  });
+
+  it('does not emit the slug warning when template_id is supplied (id takes precedence)', async () => {
+    (apiClientMock.post as Mock).mockResolvedValueOnce(respWithId(4321));
+
+    const result = await createTestCaseReal(
+      { ...baseArgs, template: 'test_case_sec', template_id: 4321 },
+      mockConfig as any,
+    );
+
+    const text = (result.content ?? []).map((c: any) => c.text).join('\n');
+    expect(text).not.toContain('The \'template\' field accepts only');
+  });
+
+  it('reads the case back and warns when template_id is omitted from the create response but not applied', async () => {
+    // Real API: create response carries `template` (step_type) but no template_id.
+    (apiClientMock.post as Mock).mockResolvedValueOnce(resp('test_case_steps'));
+    // Read-back via v1 search shows the default (2) was applied, not 656127.
+    (apiClientMock.get as Mock).mockResolvedValueOnce({
+      data: { test_cases: [{ identifier: 'TC-1', template_id: 2 }] },
+    });
+
+    const result = await createTestCaseReal(
+      { ...baseArgs, template_id: 656127 },
+      mockConfig as any,
+    );
+
+    const getUrl = (apiClientMock.get as Mock).mock.calls[0][0].url;
+    expect(getUrl).toContain('/test-cases/search');
+    const text = (result.content ?? []).map((c: any) => c.text).join('\n');
+    expect(text).toContain('template_id 656127 was not applied');
+    expect(text).toContain('template_id 2');
+  });
+
+  // template_id is honoured only by the v1 create endpoint (v2 strips it), so a
+  // template_id request must route to /api/v1/.../test-cases with API-TOKEN auth
+  // and the folder carried in the body.
+  it('routes to the v1 create endpoint with API-TOKEN auth when template_id is set', async () => {
+    (apiClientMock.post as Mock).mockResolvedValueOnce(respWithId(656127));
+
+    await createTestCaseReal(
+      { ...baseArgs, folder_id: '50', template_id: 656127 },
+      mockConfig as any,
+    );
+
+    const call = (apiClientMock.post as Mock).mock.calls[0][0];
+    expect(call.url).toContain('/api/v1/projects/');
+    expect(call.url).toContain('/test-cases');
+    expect(call.url).not.toContain('/folders/'); // folder goes in the body for v1
+    expect(call.headers['API-TOKEN']).toBe('fake-user:fake-key');
+    expect(call.headers.Authorization).toBeUndefined();
+    expect(call.body.folder_id).toBe(50);
+    expect(call.body.test_case.test_case_folder_id).toBe(50);
+    expect(call.body.test_case.template_id).toBe(656127);
+    // MCP-only params must not leak into the v1 test_case payload.
+    expect(call.body.test_case.project_identifier).toBeUndefined();
+    expect(call.body.test_case.folder_id).toBeUndefined();
+  });
+
+  it('translates custom_fields name→id and option value→id on the v1 path', async () => {
+    const api = await import('../../src/tools/testmanagement-utils/TCG-utils/api');
+    (api.fetchFormFields as Mock).mockResolvedValueOnce({
+      default_fields: {},
+      custom_fields: [
+        {
+          field_name: 'aaas',
+          id: 194184,
+          field_type: 'field_multi_dropdown',
+          option_values: [
+            { option_value: 'm40', id: 111 },
+            { option_value: 'm48', id: 222 },
+          ],
+        },
+      ],
+    });
+    (apiClientMock.post as Mock).mockResolvedValueOnce(respWithId(656127));
+
+    await createTestCaseReal(
+      {
+        ...baseArgs,
+        folder_id: '50',
+        template_id: 656127,
+        custom_fields: { aaas: ['m40', 'm48'] },
+      },
+      mockConfig as any,
+    );
+
+    const body = (apiClientMock.post as Mock).mock.calls[0][0].body;
+    expect(body.test_case.custom_fields).toEqual({ 194184: [111, 222] });
+  });
 });
 
-// PMAA-131: multi-select custom fields on the update (PATCH) path.
+// Multi-select custom fields on the update (PATCH) path.
 describe('updateTestCase — multi-select custom_fields', () => {
   let updateTestCaseReal: typeof import('../../src/tools/testmanagement-utils/update-testcase').updateTestCase;
   let apiClientMock: typeof import('../../src/lib/apiClient').apiClient;
@@ -1286,5 +1419,67 @@ describe('updateTestCase — multi-select custom_fields', () => {
     expect(result.isError).toBeFalsy();
     const body = (apiClientMock.patch as Mock).mock.calls[0][0].body;
     expect(body.test_case.custom_fields).toEqual({ aaas: ['m40', 'm48'] });
+  });
+});
+
+// listTestCaseTemplates resolves a template name to a template_id.
+describe('listTemplates', () => {
+  let listTemplatesReal: typeof import('../../src/tools/testmanagement-utils/list-templates').listTemplates;
+  let apiClientMock: typeof import('../../src/lib/apiClient').apiClient;
+
+  beforeAll(async () => {
+    const actual = await vi.importActual<
+      typeof import('../../src/tools/testmanagement-utils/list-templates')
+    >('../../src/tools/testmanagement-utils/list-templates');
+    listTemplatesReal = actual.listTemplates;
+    apiClientMock = (await import('../../src/lib/apiClient')).apiClient;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const templatesResp = {
+    data: {
+      success: true,
+      templates: [
+        { id: 2, name: 'Test Case Steps', step_type: 'test_case_steps', is_system: true, is_default: true, enabled: true },
+        { id: 42, name: 'Test Case - SEC', step_type: 'test_case_steps', is_system: false, is_default: false, enabled: true },
+      ],
+    },
+  };
+
+  it('queries the admin-v2 templates endpoint with API-TOKEN auth and surfaces ids', async () => {
+    (apiClientMock.get as Mock).mockResolvedValueOnce(templatesResp);
+
+    const result = await listTemplatesReal({}, mockConfig as any);
+
+    const call = (apiClientMock.get as Mock).mock.calls[0][0];
+    expect(call.url).toContain('/api/v1/admin-v2/settings/templates');
+    expect(call.url).toContain('entity_type=TestCase');
+    expect(call.headers['API-TOKEN']).toBe('fake-user:fake-key');
+
+    const text = (result.content ?? []).map((c: any) => c.text).join('\n');
+    expect(text).toContain('template_id=42');
+    expect(text).toContain('Test Case - SEC');
+  });
+
+  it('filters by name client-side', async () => {
+    (apiClientMock.get as Mock).mockResolvedValueOnce(templatesResp);
+
+    const result = await listTemplatesReal({ name: 'SEC' }, mockConfig as any);
+
+    const text = (result.content ?? []).map((c: any) => c.text).join('\n');
+    expect(text).toContain('Test Case - SEC');
+    expect(text).not.toContain('[template_id=2]');
+    expect(text).toContain('Found 1 template');
+  });
+
+  it('reports when no templates match the name filter', async () => {
+    (apiClientMock.get as Mock).mockResolvedValueOnce(templatesResp);
+
+    const result = await listTemplatesReal({ name: 'nope' }, mockConfig as any);
+    const text = (result.content ?? []).map((c: any) => c.text).join('\n');
+    expect(text).toContain('No templates matching "nope"');
   });
 });


### PR DESCRIPTION
## What & why

Follow-up to #319 (which added a `template` param that only selects *system* templates). This adds the ability to create a test case with a **custom template**, plus a way to discover template ids. Both **verified end-to-end against prod**.

## The key finding

A custom template can only be selected by numeric **`template_id`** — the `template` slug only ever picks a system template (`step_type` is constrained to `test_case_steps`/`test_case_bdd` and isn't unique).

`createTestCase` therefore routes to the **v1** create endpoint when a `template_id` is supplied (it honours the id), and keeps using the **v2** endpoint otherwise.

## Why not the documented v2 endpoint?

The natural choice would be the documented v2 create (`POST /api/v2/projects/{id}/folders/{folder_id}/test-cases`). It **cannot apply a custom template**, confirmed two ways:

**1. No template-selection field exists in the v2 contract.** The [documented request body](https://www.browserstack.com/docs/test-management/api-reference/test-cases#create-a-test-case) is `name, description, owner, preconditions, test_case_steps, issues, issue_tracker, tags, case_type, priority, custom_fields`. There is no `template_id` / `template_name`. The only documented `template` value is `"test_case_bdd"` — a *system step-type*, not a custom template.

**2. v2 silently ignores `template_id` at runtime.** A direct call with a valid, project-linked custom template id returns `HTTP 200 success:true`, but the field is dropped — the case is created with the **default** template:

```
POST /api/v2/projects/PR-…/folders/…/test-cases
Body: {"test_case":{"name":"…","template_id":656127,"test_case_steps":[…]}}

→ HTTP 200, success:true
   response.template_id : <absent>
   response.template    : "test_case_steps"
   read-back template_id: 2   (default — NOT the requested 656127)
```

Tested across placements — `template_id` inside `test_case`, `template_id` as a top-level sibling, and `template` set to the numeric id string — **all** produced the default template. So this is not a payload-shape issue; the v2 endpoint does not carry template selection at all.

**v1 is the only public endpoint that honours `template_id`** (it is also the endpoint the TM web dashboard itself uses for template-based creates), so the PR uses v1 for that path only.

## How v1 is wired in

- When `template_id` is set → `POST /api/v1/projects/{numericId}/test-cases` (API-TOKEN auth, folder carried in the body). Same user credentials as the rest of the server (`getBrowserStackAuth(config)`), same `API-TOKEN` header style already used by `form-fields-v2` / project lookup / TCG calls.
- v1 keys `custom_fields` by **id** with **option ids**, whereas v2 keys by **name** with **values** — so on the v1 path we translate the by-name shape → v1's by-id shape via the project's form fields, keeping multi-select custom fields working alongside a template.
- With no `template_id`, the proven **v2 path is unchanged** — zero regression for the common case.
- A post-create read-back warns if the applied template differs from the request — so if v2 ever gains `template_id` support (see below) and we migrate back, any regression surfaces loudly instead of silently.

## Changes

- **`list-templates.ts`** — `listTestCaseTemplates` tool → `GET /api/v1/admin-v2/settings/templates?entity_type=TestCase` (API-TOKEN), client-side `name` filter.
- **`create-testcase.ts`** — `template_id` param; v1 routing when set; `toV1CustomFields` translation; post-create read-back warning.

## Testing

`npm run build` green — lint, format, **tsc**, and **198 tests** pass.

### Existing tests (sanity)

The pre-existing `testmanagement` suite is unchanged and still green — notably the v2 default create path, priority normalization, the `template` system-slug pass-through + silent-fallback warning, and the multi-select `custom_fields`-by-name behaviour from #319 all continue to pass (this PR leaves the no-`template_id` path entirely on v2).

### New tests (9)

**`createTestCase` — `template_id` routing & verification (6)**

1. **passes `template_id` through to the request body and does not warn when applied** — `template_id` reaches `body.test_case.template_id`; no mismatch warning when the applied template equals the requested one.
2. **warns when the API applies a different `template_id` than requested** — if the created case comes back with a different `template_id`, the tool surfaces a clear mismatch warning instead of reporting plain success.
3. **does not emit the slug warning when `template_id` is supplied (id takes precedence)** — the `template` system-slug fallback warning is suppressed when `template_id` is present, so the two paths don't double-warn.
4. **reads the case back and warns when `template_id` is omitted from the create response but not applied** — the real create response has no `template_id`, so the tool re-reads the case via the v1 search endpoint and warns when the applied template differs (covers the silent-miss failure mode).
5. **routes to the v1 create endpoint with API-TOKEN auth when `template_id` is set** — asserts the request targets `/api/v1/projects/{id}/test-cases` with the `API-TOKEN` header (not v2 + Basic), the folder is carried in the body (`folder_id` top-level **and** `test_case.test_case_folder_id`), and MCP-only params (`project_identifier`, `folder_id`) do not leak into the `test_case` payload.
6. **translates `custom_fields` name→id and option value→id on the v1 path** — with form fields mocked, `{ aaas: ["m40","m48"] }` (v2/by-name shape) is rewritten to `{ 194184: [111, 222] }` (v1/by-id shape) in the request body.

**`listTestCaseTemplates` (3)**

7. **queries the admin-v2 templates endpoint with API-TOKEN auth and surfaces ids** — hits `GET /api/v1/admin-v2/settings/templates?entity_type=TestCase` with the `API-TOKEN` header and returns each template's numeric id and name.
8. **filters by name client-side** — a `name` argument narrows the returned list (matching template kept, non-matching default dropped) and the count reflects the filtered set.
9. **reports when no templates match the name filter** — returns a clear `No templates matching "…"` message rather than an empty/confusing result.

### End-to-end verification (prod, throwaway folder, deleted after)

| Path | Result |
|---|---|
| `listTestCaseTemplates` via compiled tool | returned real templates with ids ✅ |
| `createTestCase` with a custom `template_id` | applied that template (not the default) ✅ |
| `createTestCase` with `template_id` + multi-select `custom_fields` + priority + tags + steps | applied the requested template **and** both custom-field values, plus priority/tags/steps — `isError:false` ✅ |
| `createTestCase` with an **invalid** `template_id` | rejected with a clear error, nothing created (no silent fallback) ✅ |
| `createTestCase` with **no** `template_id` (v2 path) | unchanged ✅ |

Server boots clean and registers all tools.

## Notes / limitations / follow-up

- The v1 create endpoint is undocumented (though it is what the TM dashboard uses); the read-back warning guards against silent regression. **Follow-up:** request `template_id` support on the documented v2 create so this path can move back to v2.
- BDD *custom* templates would also need `feature`/`scenario` fields on the schema (today's schema is steps-oriented) — out of scope.