### PR TITLE
chore: bump version to 1.2.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserstack/mcp-server",
-      "version": "1.2.24",
+      "version": "1.2.25",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "description": "BrowserStack's Official MCP Server",
   "mcpName": "io.github.browserstack/mcp-server",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@browserstack/mcp-server",
-      "version": "1.2.24",
+      "version": "1.2.25",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump **1.2.24 → 1.2.25** ahead of the next npm release, per the manual-bump release flow.

Updates the version in all three files:
- `package.json` → `version`
- `package-lock.json` → top-level `version` and the root `packages.""` entry
- `server.json` → `packages[].version` (top-level `version` stays `1.0.0`, it's the schema version)

Only the four version lines change; no code changes.

### ⚠️ Merge order
This bump is what the `Release New Version` workflow publishes from `main`. For the release to include the custom-template / `listTestCaseTemplates` work, **merge #328 first, then this bump, then dispatch the release.** If #328 isn't in `main` when the release runs, 1.2.25 will ship without it.