### PR TITLE
feat(rca): listTestIds returns ALL tests of a build (each with status)

### DIFF
--- a/src/tools/rca-agent-utils/get-failed-test-id.ts
+++ b/src/tools/rca-agent-utils/get-failed-test-id.ts
@@ -18,9 +18,11 @@ export async function getTestIds(
   status?: TestStatus,
   includeFailureDetail = false,
 ): Promise<FailedTestInfo[]> {
+  // No `status` → no `test_statuses` filter → the endpoint returns ALL tests
+  // (the default). A `status` narrows both the query and the extraction.
   const baseUrl = `${getAutomationBaseUrl()}/ext/v1/builds/${buildId}/testRuns`;
   let url = status ? `${baseUrl}?test_statuses=${status}` : baseUrl;
-  let allFailedTests: FailedTestInfo[] = [];
+  let allTests: FailedTestInfo[] = [];
   let requestNumber = 0;
 
   // Construct Basic auth header
@@ -46,14 +48,14 @@ export async function getTestIds(
 
       const data = (await response.json()) as TestRun;
 
-      // Extract failed IDs from current page
+      // Extract test IDs from the current page (all tests unless narrowed).
       if (data.hierarchy && data.hierarchy.length > 0) {
-        const currentFailedTests = extractFailedTestIds(
+        const currentTests = extractTestIds(
           data.hierarchy,
           status,
           includeFailureDetail,
         );
-        allFailedTests = allFailedTests.concat(currentFailedTests);
+        allTests = allTests.concat(currentTests);
       }
 
       // Check for pagination termination conditions
@@ -73,52 +75,59 @@ export async function getTestIds(
       url = `${baseUrl}?${new URLSearchParams(params).toString()}`;
     }
 
-    // Return unique failed test IDs
-    return allFailedTests;
+    return allTests;
   } catch (error) {
-    logger.error("Error fetching failed tests:", error);
+    logger.error("Error fetching test runs:", error);
     throw error;
   }
 }
 
-export function extractFailedTestIds(
+export function extractTestIds(
   hierarchy: TestDetails[],
   status?: TestStatus,
   includeFailureDetail = false,
 ): FailedTestInfo[] {
-  let failedTests: FailedTestInfo[] = [];
+  let tests: FailedTestInfo[] = [];
 
   for (const node of hierarchy) {
-    // Match on status alone — the observability_url `details=<id>` check below
-    // already filters to real test nodes (suite/hook nodes carry no status and
-    // no such URL). Do NOT also require run_count: JUnit-uploaded builds report
-    // run_count=0 even for genuinely failed tests, which would drop them all.
-    if (node.details?.status === status) {
-      if (node.details?.observability_url) {
-        const idMatch = node.details.observability_url.match(/details=(\d+)/);
-        if (idMatch) {
-          const entry: FailedTestInfo = {
-            test_id: idMatch[1],
-            test_name: node.display_name || `Test ${idMatch[1]}`,
-          };
-          if (includeFailureDetail) {
-            const signature = buildFailureSignature(node.details);
-            if (signature) entry.failure = signature;
-          }
-          failedTests.push(entry);
+    // Include every REAL test node. The observability_url `details=<id>` check
+    // already filters out suite/hook nodes (they carry no such URL). We do NOT
+    // require run_count: JUnit-uploaded builds report run_count=0 even for
+    // genuine tests, which would drop them all.
+    // Status filtering is optional: when `status` is omitted we return ALL
+    // tests (the default); when provided we narrow to that status.
+    const nodeStatus = node.details?.status;
+    const statusMatches = status === undefined || nodeStatus === status;
+    if (statusMatches && node.details?.observability_url) {
+      const idMatch = node.details.observability_url.match(/details=(\d+)/);
+      if (idMatch) {
+        const entry: FailedTestInfo = {
+          test_id: idMatch[1],
+          test_name: node.display_name || `Test ${idMatch[1]}`,
+          status: nodeStatus,
+        };
+        // Failure signatures only exist for failed tests; include when asked.
+        if (includeFailureDetail && nodeStatus === TestStatus.FAILED) {
+          const signature = buildFailureSignature(node.details);
+          if (signature) entry.failure = signature;
         }
+        tests.push(entry);
       }
     }
 
     if (node.children && node.children.length > 0) {
-      failedTests = failedTests.concat(
-        extractFailedTestIds(node.children, status, includeFailureDetail),
+      tests = tests.concat(
+        extractTestIds(node.children, status, includeFailureDetail),
       );
     }
   }
 
-  return failedTests;
+  return tests;
 }
+
+// Back-compat alias — prefer extractTestIds. Kept so existing imports/tests
+// referencing the old name continue to resolve.
+export const extractFailedTestIds = extractTestIds;
 
 // Build a trimmed failure signature from a test node's `details`. Returns
 // undefined when no signal is available so the field is simply omitted.

--- a/src/tools/rca-agent-utils/types.ts
+++ b/src/tools/rca-agent-utils/types.ts
@@ -34,7 +34,11 @@ export interface TestFailureSignature {
 export interface FailedTestInfo {
   test_id: number;
   test_name: string;
-  // Present only when listTestIds is called with includeFailureDetail=true.
+  // The test's own status (passed/failed/pending/skipped). listTestIds returns
+  // ALL tests by default, so consumers rely on this to filter/group.
+  status?: TestStatus;
+  // Present only when listTestIds is called with includeFailureDetail=true
+  // (only failed tests carry a signature).
   failure?: TestFailureSignature;
 }
 

--- a/src/tools/rca-agent.ts
+++ b/src/tools/rca-agent.ts
@@ -250,7 +250,7 @@ export default function addRCATools(
 
   tools.listTestIds = server.tool(
     "listTestIds",
-    "List test IDs from a BrowserStack Automate build, optionally filtered by status",
+    "List all tests of a BrowserStack build (each with its status); optional status filter.",
     LIST_TEST_IDS_PARAMS,
     async (args) => {
       try {

--- a/tests/tools/extract-failed-test-ids.test.ts
+++ b/tests/tools/extract-failed-test-ids.test.ts
@@ -21,7 +21,7 @@ describe("extractFailedTestIds", () => {
     const result = extractFailedTestIds(hierarchy, TestStatus.FAILED);
 
     expect(result).toEqual([
-      { test_id: "111", test_name: "zero-run failure" },
+      { test_id: "111", test_name: "zero-run failure", status: TestStatus.FAILED },
     ]);
   });
 
@@ -63,7 +63,7 @@ describe("extractFailedTestIds", () => {
     ];
 
     expect(extractFailedTestIds(hierarchy, TestStatus.FAILED)).toEqual([
-      { test_id: "333", test_name: "nested failure" },
+      { test_id: "333", test_name: "nested failure", status: TestStatus.FAILED },
     ]);
   });
 
@@ -76,7 +76,68 @@ describe("extractFailedTestIds", () => {
     ];
 
     expect(extractFailedTestIds(hierarchy, TestStatus.FAILED)).toEqual([
-      { test_id: "444", test_name: "Test 444" },
+      { test_id: "444", test_name: "Test 444", status: TestStatus.FAILED },
     ]);
+  });
+
+  it("returns ALL tests (any status) with per-test status when no status is passed", () => {
+    const hierarchy = [
+      node(
+        {
+          status: TestStatus.PASSED,
+          observability_url: "https://o.bs.com/x?details=1",
+        },
+        "passed test",
+      ),
+      node(
+        {
+          status: TestStatus.FAILED,
+          observability_url: "https://o.bs.com/x?details=2",
+        },
+        "failed test",
+      ),
+      node(
+        {
+          status: TestStatus.SKIPPED,
+          observability_url: "https://o.bs.com/x?details=3",
+        },
+        "skipped test",
+      ),
+    ];
+
+    // No status arg → every real test node, each carrying its own status.
+    expect(extractFailedTestIds(hierarchy)).toEqual([
+      { test_id: "1", test_name: "passed test", status: TestStatus.PASSED },
+      { test_id: "2", test_name: "failed test", status: TestStatus.FAILED },
+      { test_id: "3", test_name: "skipped test", status: TestStatus.SKIPPED },
+    ]);
+  });
+
+  it("includeFailureDetail attaches a signature only to FAILED tests", () => {
+    const hierarchy = [
+      node(
+        {
+          status: TestStatus.PASSED,
+          observability_url: "https://o.bs.com/x?details=10",
+          failure_categories: ["ShouldBeIgnored"],
+        },
+        "passed",
+      ),
+      node(
+        {
+          status: TestStatus.FAILED,
+          observability_url: "https://o.bs.com/x?details=11",
+          failure_categories: ["ProductError"],
+        },
+        "failed",
+      ),
+    ];
+
+    const result = extractFailedTestIds(hierarchy, undefined, true);
+    expect(result).toHaveLength(2);
+    expect(result.find((r) => r.test_id === "10")?.failure).toBeUndefined();
+    expect(result.find((r) => r.test_id === "11")?.failure?.category).toBe(
+      "ProductError",
+    );
   });
 });

--- a/tests/tools/getFailedTestId.test.ts
+++ b/tests/tools/getFailedTestId.test.ts
@@ -51,7 +51,7 @@ describe("getTestIds — failure signature extraction", () => {
 
     const result = await getTestIds("build-1", AUTH, TestStatus.FAILED);
 
-    expect(result).toEqual([{ test_id: "101", test_name: "login test" }]);
+    expect(result).toEqual([{ test_id: "101", test_name: "login test", status: TestStatus.FAILED }]);
     expect(result[0]).not.toHaveProperty("failure");
   });
 
@@ -176,7 +176,7 @@ describe("getTestIds — failure signature extraction", () => {
 
     const result = await getTestIds("build-1", AUTH, TestStatus.FAILED);
 
-    expect(result).toEqual([{ test_id: "142", test_name: "uploaded test" }]);
+    expect(result).toEqual([{ test_id: "142", test_name: "uploaded test", status: TestStatus.FAILED }]);
   });
 
   it("extracts signatures from nested children", async () => {


### PR DESCRIPTION
Previously listTestIds only worked when a status filter was passed — calling it without one returned nothing (extraction matched node.details.status === status, which is false for every real test when status is undefined). Now:
- No status → every real test node is returned, each carrying its own status (passed/failed/pending/skipped). Same obs-api endpoint (/ext/v1/builds/{id}/ testRuns), which already returns all statuses when test_statuses is omitted.
- Optional status still narrows the result (server query + extraction), so callers like the rca-build skill that pass status='failed' are unchanged.
- FailedTestInfo gains ; failure signatures attach only to FAILED tests.
- extractFailedTestIds kept as an alias of the renamed extractTestIds. Build gate green (267 tests).