### PR TITLE
fix(rca): raise listTestIds pagination cap (was silently truncating a…

### DIFF
--- a/src/tools/rca-agent-utils/get-failed-test-id.ts
+++ b/src/tools/rca-agent-utils/get-failed-test-id.ts
@@ -12,6 +12,10 @@ import {
 // return full stack traces into the MCP client's context window).
 const ERROR_SUMMARY_MAX = 200;
 
+// Safety bound on pagination — high enough to cover large builds, low enough to
+// prevent a runaway loop. Truncation (if ever hit) is logged, never silent.
+const MAX_PAGES = 100;
+
 export async function getTestIds(
   buildId: string,
   authString: string,
@@ -58,12 +62,17 @@ export async function getTestIds(
         allTests = allTests.concat(currentTests);
       }
 
-      // Check for pagination termination conditions
-      if (
-        !data.pagination?.has_next ||
-        !data.pagination.next_page ||
-        requestNumber >= 5
-      ) {
+      // Paginate to the end. A safety bound prevents a runaway loop, but it is
+      // high enough to cover large builds (the old cap of 5 pages silently
+      // truncated builds with more than ~5 pages of tests). If we ever hit the
+      // bound we log it rather than returning a silently-partial list.
+      if (!data.pagination?.has_next || !data.pagination.next_page) {
+        break;
+      }
+      if (requestNumber >= MAX_PAGES) {
+        logger.warn(
+          `listTestIds: hit MAX_PAGES (${MAX_PAGES}) for build ${buildId}; result may be partial`,
+        );
         break;
       }
 


### PR DESCRIPTION
…t 5 pages)

The old requestNumber>=5 cap dropped tests for any build with >5 pages — e.g. build 11fdi8f5… returned 117 tests/7 failed when the true totals are 171/9 (8 pages). Bumped to MAX_PAGES=100 and log a warning if ever hit, so results are never silently partial. Now returns all 171 tests / 9 failed.