### PR TITLE
chore: bump version to 1.2.31 in package.json, package-lock.json, and server.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserstack/mcp-server",
-      "version": "1.2.30",
+      "version": "1.2.31",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "description": "BrowserStack's Official MCP Server",
   "mcpName": "io.github.browserstack/mcp-server",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@browserstack/mcp-server",
-      "version": "1.2.30",
+      "version": "1.2.31",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bumps the package version from 1.2.30 to 1.2.31 across package.json, package-lock.json, and server.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)