### PR TITLE
feat(rca): add getTfaTurnResult one-shot turn read

### DIFF
--- a/src/tools/tfa-rca-collaboration.ts
+++ b/src/tools/tfa-rca-collaboration.ts
@@ -4,14 +4,19 @@ import { trackMCP } from "../lib/instrumentation.js";
 import { handleMCPError } from "../lib/utils.js";
 import { BrowserStackConfig } from "../lib/types.js";
 import {
+  GET_TFA_TURN_RESULT_PARAMS,
   TFA_RCA_TURN_PARAMS,
   TRIGGER_RCA_REPORT_PARAMS,
 } from "./tfa-rca-utils/constants.js";
 import {
   submitTfaRcaTurn,
   TfaRcaTurnArgs,
-  TfaRcaTurnError,
 } from "./tfa-rca-utils/submit-turn.js";
+import {
+  getTfaTurnResult,
+  GetTfaTurnResultArgs,
+  TfaRcaTurnError,
+} from "./tfa-rca-utils/turn-result.js";
 import {
   triggerRcaReport,
   TriggerRcaReportArgs,
@@ -19,6 +24,7 @@ import {
 } from "./tfa-rca-utils/trigger-report.js";
 
 const TOOL_NAME = "tfaRcaTurn";
+const GET_RESULT_TOOL_NAME = "getTfaTurnResult";
 const TRIGGER_TOOL_NAME = "triggerRcaReport";
 
 /** Wrap a domain error into the standard `{ isError: true }` envelope. */
@@ -43,6 +49,22 @@ export async function tfaRcaTurnTool(
   // The util returns the trimmed, status-discriminated contract; JSON.stringify
   // drops the undefined slots, so the wrapper stays a plain serializer.
   const result = await submitTfaRcaTurn(args, config, context);
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}
+
+export async function getTfaTurnResultTool(
+  args: GetTfaTurnResultArgs,
+  config: BrowserStackConfig,
+): Promise<CallToolResult> {
+  // Same trimmed contract as `tfaRcaTurn`, read once without submitting.
+  const result = await getTfaTurnResult(args, config);
   return {
     content: [
       {
@@ -95,6 +117,36 @@ export default function addTfaRcaCollaborationTools(
           return domainErrorResult(TOOL_NAME, error);
         }
         return handleMCPError(TOOL_NAME, server, config, error);
+      }
+    },
+  );
+
+  tools.getTfaTurnResult = server.tool(
+    GET_RESULT_TOOL_NAME,
+    "Read a submitted RCA turn's result once by turnId; PENDING if the agent is still working.",
+    GET_TFA_TURN_RESULT_PARAMS,
+    async (args) => {
+      try {
+        const result = await getTfaTurnResultTool(args, config);
+        trackMCP(
+          GET_RESULT_TOOL_NAME,
+          server.server.getClientVersion()!,
+          undefined,
+          config,
+        );
+        return result;
+      } catch (error) {
+        // Domain failures carry a client-safe, group-scope-safe message.
+        if (error instanceof TfaRcaTurnError) {
+          trackMCP(
+            GET_RESULT_TOOL_NAME,
+            server.server.getClientVersion()!,
+            error,
+            config,
+          );
+          return domainErrorResult(GET_RESULT_TOOL_NAME, error);
+        }
+        return handleMCPError(GET_RESULT_TOOL_NAME, server, config, error);
       }
     },
   );

--- a/src/tools/tfa-rca-utils/constants.ts
+++ b/src/tools/tfa-rca-utils/constants.ts
@@ -96,6 +96,15 @@ export const TFA_RCA_TURN_PARAMS = {
 };
 
 /**
+ * Zod param shapes for the `getTfaTurnResult` tool — a one-shot read of an
+ * already-submitted turn. No credential fields (security rule).
+ */
+export const GET_TFA_TURN_RESULT_PARAMS = {
+  testRunId: z.string().describe("Test run id the turn was submitted on."),
+  turnId: z.string().describe("Turn id returned by tfaRcaTurn."),
+};
+
+/**
  * Zod param shapes for the `triggerRcaReport` tool. No credential fields
  * (security rule). Each `.describe()` ≤ 60 chars.
  */

--- a/src/tools/tfa-rca-utils/submit-turn.ts
+++ b/src/tools/tfa-rca-utils/submit-turn.ts
@@ -1,23 +1,23 @@
 import { apiClient } from "../../lib/apiClient.js";
-import { getBrowserStackAuth } from "../../lib/get-auth.js";
 import { BrowserStackConfig } from "../../lib/types.js";
 import {
   getO11yBaseUrl,
-  getRcaViewGuidance,
   POLL_INITIAL_DELAY_MS,
   POLL_INTERVAL_MS,
   POLL_MAX_WAIT_MS,
-  RCA_CHAT_POLL_PATH,
   RCA_CHAT_SUBMIT_PATH,
-  RCA_GLIMPSE_ROOT_CAUSE_MAX,
 } from "./constants.js";
+import { PENDING_STATUS, TfaRcaTurnResult } from "./types.js";
 import {
-  PENDING_STATUS,
-  TfaAsk,
-  TfaRcaTurnResult,
-  TfaStatus,
-  TurnResponse,
-} from "./types.js";
+  buildAuthHeader,
+  buildPollUrl,
+  readStructuredTurn,
+  TfaRcaTurnError,
+  toTrimmedResult,
+} from "./turn-result.js";
+
+// Re-exported so existing importers keep a single entry point for the error type.
+export { TfaRcaTurnError };
 
 interface TurnContext {
   sendNotification?: (notification: any) => Promise<void>;
@@ -32,18 +32,7 @@ export interface TfaRcaTurnArgs {
   turnId?: string;
 }
 
-/**
- * Domain error carrying a client-safe message. The tool maps these to a
- * `{ isError: true }` envelope; the message never contains credentials.
- */
-export class TfaRcaTurnError extends Error {}
-
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-function buildAuthHeader(config: BrowserStackConfig): string {
-  const authString = getBrowserStackAuth(config);
-  return `Basic ${Buffer.from(authString).toString("base64")}`;
-}
 
 async function notify(
   context: TurnContext | undefined,
@@ -60,116 +49,6 @@ async function notify(
       total: 100,
     },
   });
-}
-
-/** Map a raw status string from the wire onto the `TfaStatus` enum. */
-function toTfaStatus(raw: unknown): TfaStatus {
-  switch (raw) {
-    case "RESOLVED":
-      return TfaStatus.RESOLVED;
-    case "BLOCKED":
-      return TfaStatus.BLOCKED;
-    default:
-      return TfaStatus.NEEDS_INFO;
-  }
-}
-
-/** Map one wire ask (snake_case) to the client `TfaAsk` (camelCase). */
-function toAsk(raw: any): TfaAsk {
-  return {
-    what: raw?.what ?? "",
-    why: raw?.why ?? "",
-    evidenceType: raw?.evidence_type ?? "other",
-    priority: raw?.priority ?? "medium",
-  };
-}
-
-/**
- * Read the LLM-enforced structured turn from the completed `rcaChat` poll body.
- *
- * The poll envelope's own `status` field is the lifecycle state
- * (`working`/`completed`/`failed`); the agent's `TurnResponse` is passed
- * through under `turn` so its `status` (NEEDS_INFO/RESOLVED/BLOCKED) never
- * collides with the lifecycle one. The agent's model validator guarantees the
- * sub-object matching the turn status is present; we still default-fill the
- * lists so the skill never sees `undefined`.
- */
-function readStructuredTurn(data: any): TurnResponse {
-  const turn = data.turn ?? {};
-  const status = toTfaStatus(turn.status);
-  const needsInfo = turn.needs_info ?? {};
-  const blocked = turn.blocked ?? {};
-
-  return {
-    status,
-    confidence: turn.confidence ?? "unknown",
-    questions: Array.isArray(needsInfo.questions) ? needsInfo.questions : [],
-    asks: Array.isArray(needsInfo.asks) ? needsInfo.asks.map(toAsk) : [],
-    suggestions: Array.isArray(needsInfo.suggestions)
-      ? needsInfo.suggestions
-      : [],
-    hypotheses: Array.isArray(needsInfo.hypotheses) ? needsInfo.hypotheses : [],
-    rca: status === TfaStatus.RESOLVED ? (turn.rca ?? undefined) : undefined,
-    reason: status === TfaStatus.BLOCKED ? blocked.reason : undefined,
-    unmetAsks:
-      status === TfaStatus.BLOCKED && Array.isArray(blocked.unmet_asks)
-        ? blocked.unmet_asks
-        : undefined,
-  };
-}
-
-/** Truncate to `max` chars total (ellipsis included when cut). */
-function truncate(text: string | undefined, max: number): string | undefined {
-  if (text === undefined) return undefined;
-  return text.length > max ? text.slice(0, max - 1) + "…" : text;
-}
-
-/**
- * Trim a completed turn to the status-discriminated contract:
- * - NEEDS_INFO: questions/asks/suggestions/hypotheses VERBATIM (the client
- *   loop consumes them).
- * - RESOLVED: glimpse only (root_cause truncated, failure_type, related_prs)
- *   + a `viewRca` pointer — the full RCA lives on the TRA dashboard.
- * - BLOCKED: reason + unmetAsks.
- */
-function toTrimmedResult(
-  turn: TurnResponse,
-  threadId: string | undefined,
-): TfaRcaTurnResult {
-  switch (turn.status) {
-    case TfaStatus.RESOLVED: {
-      const rca = turn.rca ?? {};
-      return {
-        status: turn.status,
-        confidence: turn.confidence,
-        threadId,
-        glimpse: {
-          root_cause: truncate(rca.root_cause, RCA_GLIMPSE_ROOT_CAUSE_MAX),
-          failure_type: rca.failure_type,
-          related_prs: rca.related_prs,
-        },
-        viewRca: getRcaViewGuidance(),
-      };
-    }
-    case TfaStatus.BLOCKED:
-      return {
-        status: turn.status,
-        confidence: turn.confidence,
-        threadId,
-        reason: turn.reason,
-        unmetAsks: turn.unmetAsks,
-      };
-    default:
-      return {
-        status: turn.status,
-        confidence: turn.confidence,
-        threadId,
-        questions: turn.questions,
-        asks: turn.asks,
-        suggestions: turn.suggestions,
-        hypotheses: turn.hypotheses,
-      };
-  }
 }
 
 /** Map a submit (POST) non-2xx into a clean, group-scope-safe domain error. */
@@ -240,12 +119,7 @@ export async function submitTfaRcaTurn(
   }
 
   // Poll to completion, soft-PENDING on wall-clock cap.
-  const pollUrl =
-    baseUrl +
-    RCA_CHAT_POLL_PATH.replace("{testRunId}", args.testRunId).replace(
-      "{turnId}",
-      turnId,
-    );
+  const pollUrl = buildPollUrl(args.testRunId, turnId);
 
   await delay(POLL_INITIAL_DELAY_MS);
   const startTime = Date.now();

--- a/src/tools/tfa-rca-utils/turn-result.ts
+++ b/src/tools/tfa-rca-utils/turn-result.ts
@@ -1,0 +1,204 @@
+import { apiClient } from "../../lib/apiClient.js";
+import { getBrowserStackAuth } from "../../lib/get-auth.js";
+import { BrowserStackConfig } from "../../lib/types.js";
+import {
+  getO11yBaseUrl,
+  getRcaViewGuidance,
+  RCA_CHAT_POLL_PATH,
+  RCA_GLIMPSE_ROOT_CAUSE_MAX,
+} from "./constants.js";
+import {
+  PENDING_STATUS,
+  TfaAsk,
+  TfaRcaTurnResult,
+  TfaStatus,
+  TurnResponse,
+} from "./types.js";
+
+/**
+ * Domain error carrying a client-safe message. The tool maps these to a
+ * `{ isError: true }` envelope; the message never contains credentials.
+ */
+export class TfaRcaTurnError extends Error {}
+
+export interface GetTfaTurnResultArgs {
+  testRunId: string;
+  turnId: string;
+}
+
+export function buildAuthHeader(config: BrowserStackConfig): string {
+  const authString = getBrowserStackAuth(config);
+  return `Basic ${Buffer.from(authString).toString("base64")}`;
+}
+
+/** Map a raw status string from the wire onto the `TfaStatus` enum. */
+function toTfaStatus(raw: unknown): TfaStatus {
+  switch (raw) {
+    case "RESOLVED":
+      return TfaStatus.RESOLVED;
+    case "BLOCKED":
+      return TfaStatus.BLOCKED;
+    default:
+      return TfaStatus.NEEDS_INFO;
+  }
+}
+
+/** Map one wire ask (snake_case) to the client `TfaAsk` (camelCase). */
+function toAsk(raw: any): TfaAsk {
+  return {
+    what: raw?.what ?? "",
+    why: raw?.why ?? "",
+    evidenceType: raw?.evidence_type ?? "other",
+    priority: raw?.priority ?? "medium",
+  };
+}
+
+/**
+ * Read the LLM-enforced structured turn from the completed `rcaChat` poll body.
+ *
+ * The poll envelope's own `status` field is the lifecycle state
+ * (`working`/`completed`/`failed`); the agent's `TurnResponse` is passed
+ * through under `turn` so its `status` (NEEDS_INFO/RESOLVED/BLOCKED) never
+ * collides with the lifecycle one. The agent's model validator guarantees the
+ * sub-object matching the turn status is present; we still default-fill the
+ * lists so the skill never sees `undefined`.
+ */
+export function readStructuredTurn(data: any): TurnResponse {
+  const turn = data.turn ?? {};
+  const status = toTfaStatus(turn.status);
+  const needsInfo = turn.needs_info ?? {};
+  const blocked = turn.blocked ?? {};
+
+  return {
+    status,
+    confidence: turn.confidence ?? "unknown",
+    questions: Array.isArray(needsInfo.questions) ? needsInfo.questions : [],
+    asks: Array.isArray(needsInfo.asks) ? needsInfo.asks.map(toAsk) : [],
+    suggestions: Array.isArray(needsInfo.suggestions)
+      ? needsInfo.suggestions
+      : [],
+    hypotheses: Array.isArray(needsInfo.hypotheses) ? needsInfo.hypotheses : [],
+    rca: status === TfaStatus.RESOLVED ? (turn.rca ?? undefined) : undefined,
+    reason: status === TfaStatus.BLOCKED ? blocked.reason : undefined,
+    unmetAsks:
+      status === TfaStatus.BLOCKED && Array.isArray(blocked.unmet_asks)
+        ? blocked.unmet_asks
+        : undefined,
+  };
+}
+
+/** Truncate to `max` chars total (ellipsis included when cut). */
+function truncate(text: string | undefined, max: number): string | undefined {
+  if (text === undefined) return undefined;
+  return text.length > max ? text.slice(0, max - 1) + "…" : text;
+}
+
+/**
+ * Trim a completed turn to the status-discriminated contract:
+ * - NEEDS_INFO: questions/asks/suggestions/hypotheses VERBATIM (the client
+ *   loop consumes them).
+ * - RESOLVED: glimpse only (root_cause truncated, failure_type, related_prs)
+ *   + a `viewRca` pointer — the full RCA lives on the TRA dashboard.
+ * - BLOCKED: reason + unmetAsks.
+ */
+export function toTrimmedResult(
+  turn: TurnResponse,
+  threadId: string | undefined,
+): TfaRcaTurnResult {
+  switch (turn.status) {
+    case TfaStatus.RESOLVED: {
+      const rca = turn.rca ?? {};
+      return {
+        status: turn.status,
+        confidence: turn.confidence,
+        threadId,
+        glimpse: {
+          root_cause: truncate(rca.root_cause, RCA_GLIMPSE_ROOT_CAUSE_MAX),
+          failure_type: rca.failure_type,
+          related_prs: rca.related_prs,
+        },
+        viewRca: getRcaViewGuidance(),
+      };
+    }
+    case TfaStatus.BLOCKED:
+      return {
+        status: turn.status,
+        confidence: turn.confidence,
+        threadId,
+        reason: turn.reason,
+        unmetAsks: turn.unmetAsks,
+      };
+    default:
+      return {
+        status: turn.status,
+        confidence: turn.confidence,
+        threadId,
+        questions: turn.questions,
+        asks: turn.asks,
+        suggestions: turn.suggestions,
+        hypotheses: turn.hypotheses,
+      };
+  }
+}
+
+/** Build the poll (GET) URL for one already-submitted turn. */
+export function buildPollUrl(testRunId: string, turnId: string): string {
+  return (
+    getO11yBaseUrl() +
+    RCA_CHAT_POLL_PATH.replace("{testRunId}", testRunId).replace(
+      "{turnId}",
+      turnId,
+    )
+  );
+}
+
+/**
+ * Read an already-submitted turn ONCE (no polling loop, no submit) and return
+ * the same trimmed, status-discriminated contract as `tfaRcaTurn`. A turn still
+ * in flight yields the soft `PENDING` status carrying `turnId`/`threadId` so the
+ * caller decides when to read again. Stateless: all identifiers are
+ * function-scoped; nothing persists between calls.
+ */
+export async function getTfaTurnResult(
+  args: GetTfaTurnResultArgs,
+  config: BrowserStackConfig,
+): Promise<TfaRcaTurnResult> {
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: buildAuthHeader(config),
+  };
+
+  const response = await apiClient.get({
+    url: buildPollUrl(args.testRunId, args.turnId),
+    headers,
+    raise_error: false,
+  });
+
+  if (response.status === 404) {
+    throw new TfaRcaTurnError("turn expired or not found");
+  }
+
+  if (!response.ok) {
+    throw new TfaRcaTurnError(
+      `failed to read RCA turn (status ${response.status})`,
+    );
+  }
+
+  const data = response.data ?? {};
+  const threadId: string | undefined = data.threadId;
+
+  if (data.status === "failed") {
+    throw new TfaRcaTurnError(data.error || "TFA agent run failed");
+  }
+
+  if (data.status === "completed") {
+    return toTrimmedResult(readStructuredTurn(data), threadId);
+  }
+
+  // "working" (or any other in-progress value) → soft PENDING, read again later.
+  return {
+    status: PENDING_STATUS,
+    threadId,
+    turnId: args.turnId,
+  };
+}

--- a/tests/tools/tfaRcaCollaboration.test.ts
+++ b/tests/tools/tfaRcaCollaboration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
 import addTfaRcaCollaborationTools, {
+  getTfaTurnResultTool,
   tfaRcaTurnTool,
 } from "../../src/tools/tfa-rca-collaboration";
 import { apiClient } from "../../src/lib/apiClient";
@@ -445,6 +446,245 @@ describe("tfaRcaTurnTool", () => {
     expect(fieldNames).toEqual(["testRunId", "message", "threadId", "turnId"]);
     expect(fieldNames).not.toContain("baseUrl");
     expect(fieldNames).not.toContain("o11yBaseUrl");
+  });
+});
+
+describe("getTfaTurnResultTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (appConfig as any).O11Y_TFA_RCA_BASE_URL = DEFAULT_O11Y_BASE_URL;
+  });
+
+  it("reads once — no submit POST, no poll loop, GET targets the turn", async () => {
+    get.mockResolvedValue(
+      completed({ status: "RESOLVED", confidence: "high", rca: {} }),
+    );
+
+    const result = await getTfaTurnResultTool(
+      { testRunId: "tr-1", turnId: "u-1" },
+      mockConfig as any,
+    );
+
+    expect(post).not.toHaveBeenCalled();
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get.mock.calls[0][0].url).toBe(
+      `${DEFAULT_O11Y_BASE_URL}/ext/v1/testRuns/tr-1/rcaChat/u-1`,
+    );
+    expect(JSON.parse(result.content[0].text as string).status).toBe("RESOLVED");
+  });
+
+  it("RESOLVED → same trimmed glimpse contract as tfaRcaTurn", async () => {
+    get.mockResolvedValue(
+      completed(
+        {
+          status: "RESOLVED",
+          confidence: "high",
+          rca: {
+            root_cause: "Config map deleted on deploy.",
+            possible_fix: "Re-add the key.",
+            failure_type: "infra",
+            related_prs: [42],
+            analysis: "very long chain of reasoning",
+          },
+        },
+        { meta: { huge: "blob".repeat(1000) } },
+      ),
+    );
+
+    const result = await getTfaTurnResultTool(
+      { testRunId: "tr-2", turnId: "u-2" },
+      mockConfig as any,
+    );
+
+    const payload = JSON.parse(result.content[0].text as string);
+    expect(payload.glimpse.root_cause).toBe("Config map deleted on deploy.");
+    expect(payload.glimpse.failure_type).toBe("infra");
+    expect(payload.glimpse.related_prs).toEqual([42]);
+    expect(payload.threadId).toBe("t-1");
+    expect(payload.viewRca).toContain("https://observability.browserstack.com");
+    // Full RCA + envelope noise dropped, exactly like the polling tool.
+    expect(payload.rca).toBeUndefined();
+    expect(result.content[0].text).not.toContain("very long chain");
+    expect(result.content[0].text).not.toContain("Re-add the key.");
+    expect(result.content[0].text).not.toContain("blob");
+  });
+
+  it("NEEDS_INFO → typed asks/questions passed through verbatim", async () => {
+    get.mockResolvedValue(
+      completed(
+        {
+          status: "NEEDS_INFO",
+          confidence: "medium",
+          needs_info: {
+            questions: ["Which service owns this endpoint?"],
+            asks: [
+              {
+                what: "deploy log for service X",
+                why: "confirm the rollout time",
+                evidence_type: "deploy",
+                priority: "high",
+              },
+            ],
+            suggestions: ["Compare against the last green build."],
+            hypotheses: ["A bad deploy dropped the config map."],
+          },
+        },
+        { threadId: "t-ni" },
+      ),
+    );
+
+    const payload = JSON.parse(
+      (
+        await getTfaTurnResultTool(
+          { testRunId: "tr-3", turnId: "u-3" },
+          mockConfig as any,
+        )
+      ).content[0].text as string,
+    );
+    expect(payload.status).toBe("NEEDS_INFO");
+    expect(payload.threadId).toBe("t-ni");
+    expect(payload.questions).toEqual(["Which service owns this endpoint?"]);
+    expect(payload.asks[0].evidenceType).toBe("deploy");
+    expect(payload.suggestions).toEqual([
+      "Compare against the last green build.",
+    ]);
+    expect(payload.hypotheses).toEqual([
+      "A bad deploy dropped the config map.",
+    ]);
+  });
+
+  it("BLOCKED → reason + unmetAsks", async () => {
+    get.mockResolvedValue(
+      completed({
+        status: "BLOCKED",
+        confidence: "low",
+        blocked: {
+          reason: "No access to the k8s cluster.",
+          unmet_asks: ["pod restart count"],
+        },
+      }),
+    );
+
+    const payload = JSON.parse(
+      (
+        await getTfaTurnResultTool(
+          { testRunId: "tr-4", turnId: "u-4" },
+          mockConfig as any,
+        )
+      ).content[0].text as string,
+    );
+    expect(payload.status).toBe("BLOCKED");
+    expect(payload.reason).toBe("No access to the k8s cluster.");
+    expect(payload.unmetAsks).toEqual(["pod restart count"]);
+  });
+
+  it("still working → soft PENDING with turnId/threadId, returns immediately", async () => {
+    get.mockResolvedValue(ok({ status: "working", threadId: "t-w" }));
+
+    const payload = JSON.parse(
+      (
+        await getTfaTurnResultTool(
+          { testRunId: "tr-5", turnId: "u-5" },
+          mockConfig as any,
+        )
+      ).content[0].text as string,
+    );
+    expect(payload.status).toBe("PENDING");
+    expect(payload.turnId).toBe("u-5");
+    expect(payload.threadId).toBe("t-w");
+    // One read only — the caller decides when to look again.
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it("failed run → clean domain error carrying upstream text", async () => {
+    get.mockResolvedValue(ok({ status: "failed", error: "agent crashed" }));
+
+    await expect(
+      getTfaTurnResultTool(
+        { testRunId: "tr-6", turnId: "u-6" },
+        mockConfig as any,
+      ),
+    ).rejects.toThrow("agent crashed");
+  });
+
+  it("404 → 'turn expired or not found', no existence leak", async () => {
+    get.mockResolvedValue(nonOk(404));
+
+    await expect(
+      getTfaTurnResultTool(
+        { testRunId: "tr-7", turnId: "u-7" },
+        mockConfig as any,
+      ),
+    ).rejects.toThrow("turn expired or not found");
+  });
+
+  it("other non-2xx → clean status-only error", async () => {
+    get.mockResolvedValue(nonOk(500));
+
+    await expect(
+      getTfaTurnResultTool(
+        { testRunId: "tr-8", turnId: "u-8" },
+        mockConfig as any,
+      ),
+    ).rejects.toThrow("failed to read RCA turn (status 500)");
+  });
+
+  it("config override → GET honors the overridden o11y host", async () => {
+    (appConfig as any).O11Y_TFA_RCA_BASE_URL =
+      "https://api-observability.bsstag.com";
+    get.mockResolvedValue(
+      completed({ status: "RESOLVED", confidence: "high" }),
+    );
+
+    await getTfaTurnResultTool(
+      { testRunId: "tr-ov", turnId: "u-ov" },
+      mockConfig as any,
+    );
+
+    expect(get.mock.calls[0][0].url).toBe(
+      "https://api-observability.bsstag.com/ext/v1/testRuns/tr-ov/rcaChat/u-ov",
+    );
+    expect(get.mock.calls[0][0].headers.Authorization).toBe(
+      `Basic ${Buffer.from("fake-user:fake-key").toString("base64")}`,
+    );
+  });
+
+  it("registers with a credential-free schema of exactly testRunId + turnId", () => {
+    const { server, tools } = buildFakeServer();
+    addTfaRcaCollaborationTools(server as any, mockConfig as any);
+    expect(Object.keys(tools.getTfaTurnResult.schema ?? {})).toEqual([
+      "testRunId",
+      "turnId",
+    ]);
+  });
+
+  it("handler success → one trackMCP; domain failure → isError envelope", async () => {
+    const { server, tools } = buildFakeServer();
+    addTfaRcaCollaborationTools(server as any, mockConfig as any);
+
+    get.mockResolvedValue(
+      completed({ status: "RESOLVED", confidence: "high" }),
+    );
+    const okResult = await tools.getTfaTurnResult.handler(
+      { testRunId: "tr-1", turnId: "u-1" },
+      undefined,
+    );
+    expect(okResult.isError).toBeFalsy();
+    expect(trackMCP).toHaveBeenCalledTimes(1);
+    expect((trackMCP as Mock).mock.calls[0][0]).toBe("getTfaTurnResult");
+    expect((trackMCP as Mock).mock.calls[0][2]).toBeUndefined();
+
+    vi.clearAllMocks();
+    get.mockResolvedValue(nonOk(404));
+    const errResult = await tools.getTfaTurnResult.handler(
+      { testRunId: "tr-1", turnId: "u-1" },
+      undefined,
+    );
+    expect(errResult.isError).toBe(true);
+    expect(errResult.content[0].text).toContain("turn expired or not found");
+    expect(errResult.content[0].text).not.toContain("fake-key");
+    expect(trackMCP).toHaveBeenCalledTimes(1);
+    expect((trackMCP as Mock).mock.calls[0][2]).toBeInstanceOf(Error);
   });
 });
 


### PR DESCRIPTION
`tfaRcaTurn` submits and polls to completion; when the wall-clock cap is hit it returns a soft PENDING carrying turnId. Reading that turn back previously meant re-entering the polling tool, which blocks the caller for up to another 90s.

Add `getTfaTurnResult({testRunId, turnId})`: a single GET on the rcaChat poll path — no submit, no loop — returning the same trimmed, status-discriminated contract (NEEDS_INFO asks/questions verbatim, RESOLVED glimpse + viewRca, BLOCKED reason/unmetAsks), or PENDING when the agent is still working so the caller decides when to read again.

The read/mapping layer (readStructuredTurn, toTrimmedResult, auth header, poll URL, TfaRcaTurnError) moves verbatim into tfa-rca-utils/turn-result.ts and is now shared by both tools. `submitTfaRcaTurn` keeps its polling loop unchanged and re-exports TfaRcaTurnError, so importers are unaffected.