### PR TITLE
fix: support inline Playwright screenshots

### DIFF
--- a/src/tools/automate-utils/fetch-screenshots.ts
+++ b/src/tools/automate-utils/fetch-screenshots.ts
@@ -4,7 +4,7 @@ import { getBrowserStackAuth } from "../../lib/get-auth.js";
 import { BrowserStackConfig } from "../../lib/types.js";
 import { apiClient } from "../../lib/apiClient.js";
 
-async function extractScreenshotUrls(
+async function extractScreenshotValues(
   sessionId: string,
   sessionType: SessionType,
   config: BrowserStackConfig,
@@ -31,7 +31,7 @@ async function extractScreenshotUrls(
       ? response.data
       : JSON.stringify(response.data);
 
-  const urls: string[] = [];
+  const values: string[] = [];
   const SCREENSHOT_PATTERN = /REQUEST.*GET.*\/screenshot/;
   const RESPONSE_VALUE_PATTERN = /"value"\s*:\s*"([^"]+)"/;
 
@@ -45,22 +45,40 @@ async function extractScreenshotUrls(
     if (SCREENSHOT_PATTERN.test(currentLine)) {
       const match = nextLine.match(RESPONSE_VALUE_PATTERN);
       if (match && match[1]) {
-        urls.push(match[1]);
+        values.push(match[1]);
       }
     }
   }
 
-  return urls;
+  return values;
 }
 
-//Converts screenshot URLs to base64 encoded images
-async function convertUrlsToBase64(
-  urls: string[],
-): Promise<Array<{ url: string; base64: string }>> {
+const PNG_BASE64_PREFIX = "iVBORw0KGgo";
+const PNG_DATA_URL_PREFIX = "data:image/png;base64,";
+
+function extractInlinePngBase64(value: string): string | undefined {
+  const base64 = value.startsWith(PNG_DATA_URL_PREFIX)
+    ? value.slice(PNG_DATA_URL_PREFIX.length)
+    : value;
+
+  return base64.startsWith(PNG_BASE64_PREFIX) ? base64 : undefined;
+}
+
+// Converts screenshot URLs or inline Playwright PNG values to base64 images.
+async function convertScreenshotValuesToBase64(
+  values: string[],
+): Promise<Array<{ url?: string; base64: string }>> {
   const screenshots = await Promise.all(
-    urls.map(async (url) => {
+    values.map(async (value) => {
+      const inlineBase64 = extractInlinePngBase64(value);
+      if (inlineBase64) {
+        return {
+          base64: await maybeCompressBase64(inlineBase64),
+        };
+      }
+
       const response = await apiClient.get({
-        url,
+        url: value,
         responseType: "arraybuffer",
       });
       // Axios returns response.data as a Buffer for binary data
@@ -70,7 +88,7 @@ async function convertUrlsToBase64(
       const compressedBase64 = await maybeCompressBase64(base64);
 
       return {
-        url,
+        url: value,
         base64: compressedBase64,
       };
     }),
@@ -79,18 +97,18 @@ async function convertUrlsToBase64(
   return screenshots;
 }
 
-//Fetches and converts screenshot URLs to base64 encoded images
+// Fetches and converts screenshot URLs or inline PNG values to base64 images.
 export async function fetchAutomationScreenshots(
   sessionId: string,
   sessionType: SessionType = SessionType.Automate,
   config: BrowserStackConfig,
 ) {
-  const urls = await extractScreenshotUrls(sessionId, sessionType, config);
-  if (urls.length === 0) {
+  const values = await extractScreenshotValues(sessionId, sessionType, config);
+  if (values.length === 0) {
     return [];
   }
 
-  // Take only the last 5 URLs
-  const lastFiveUrls = urls.slice(-5);
-  return await convertUrlsToBase64(lastFiveUrls);
+  // Take only the last 5 screenshots
+  const lastFiveValues = values.slice(-5);
+  return await convertScreenshotValuesToBase64(lastFiveValues);
 }

--- a/src/tools/automate.ts
+++ b/src/tools/automate.ts
@@ -38,7 +38,10 @@ export async function fetchAutomationScreenshotsTool(
       type: "image" as const,
       data: screenshot.base64,
       mimeType: "image/png",
-      _meta: { url: screenshot.url, index: index + 1 },
+      _meta: {
+        ...(screenshot.url ? { url: screenshot.url } : {}),
+        index: index + 1,
+      },
     }));
 
     return {

--- a/tests/tools/automate.test.ts
+++ b/tests/tools/automate.test.ts
@@ -36,6 +36,24 @@ describe("fetchAutomationScreenshotsTool", () => {
     expect(result.content[1].type).toBe("image");
   });
 
+  it("SUCCESS: omits URL metadata for inline screenshots", async () => {
+    (fetchAutomationScreenshots as Mock).mockResolvedValue([
+      { base64: "inline-png" },
+    ]);
+
+    const result = await fetchAutomationScreenshotsTool(
+      { sessionId: "sess-123", sessionType: SessionType.Automate },
+      mockConfig,
+    );
+
+    expect(result.content[1]).toEqual({
+      type: "image",
+      data: "inline-png",
+      mimeType: "image/png",
+      _meta: { index: 1 },
+    });
+  });
+
   it("SUCCESS: returns isError when no screenshots found", async () => {
     (fetchAutomationScreenshots as Mock).mockResolvedValue([]);
 

--- a/tests/tools/fetch-screenshots.test.ts
+++ b/tests/tools/fetch-screenshots.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { apiClient } from "../../src/lib/apiClient";
+import { SessionType } from "../../src/lib/constants";
+import { fetchAutomationScreenshots } from "../../src/tools/automate-utils/fetch-screenshots";
+
+vi.mock("../../src/lib/apiClient", () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+const mockConfig = {
+  "browserstack-username": "fake-user",
+  "browserstack-access-key": "fake-key",
+};
+
+function sessionLogWithScreenshotValue(value: string): string {
+  return [
+    "REQUEST GET /session/sess-123/screenshot {}",
+    `RESPONSE {"value":"${value}"}`,
+  ].join("\n");
+}
+
+describe("fetchAutomationScreenshots", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns inline Playwright PNG screenshot values without fetching them as URLs", async () => {
+    const inlinePng = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00,
+    ]).toString("base64");
+
+    (apiClient.get as Mock).mockResolvedValueOnce({
+      ok: true,
+      data: sessionLogWithScreenshotValue(inlinePng),
+    });
+
+    await expect(
+      fetchAutomationScreenshots(
+        "sess-123",
+        SessionType.Automate,
+        mockConfig,
+      ),
+    ).resolves.toEqual([{ base64: inlinePng }]);
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues to fetch screenshot URL values", async () => {
+    const screenshotUrl = "https://example.com/screenshot.png";
+    const screenshotBytes = Buffer.from("png-bytes");
+
+    (apiClient.get as Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        data: sessionLogWithScreenshotValue(screenshotUrl),
+      })
+      .mockResolvedValueOnce({ data: screenshotBytes });
+
+    await expect(
+      fetchAutomationScreenshots(
+        "sess-123",
+        SessionType.Automate,
+        mockConfig,
+      ),
+    ).resolves.toEqual([
+      {
+        url: screenshotUrl,
+        base64: screenshotBytes.toString("base64"),
+      },
+    ]);
+    expect(apiClient.get).toHaveBeenNthCalledWith(2, {
+      url: screenshotUrl,
+      responseType: "arraybuffer",
+    });
+  });
+});


### PR DESCRIPTION
Playwright Automate sessions record screenshot command results as inline base64 PNG values. `fetchAutomationScreenshots` currently assumes every log value is a URL, so these sessions fail with `Invalid URL` before the MCP server can emit image content.

This change accepts raw or data-URL PNG values directly while preserving the existing URL-backed screenshot path. Inline screenshots omit URL metadata so the base64 payload is not duplicated into `_meta`.

Regression coverage exercises both response shapes and the resulting MCP image metadata. `npm run build` passes with 231 tests.

<!-- pax-involved-start -->
## Involved

- Troels Knud Damgaard (@troelsknud)
- Pax (@hey-pax)
<!-- pax-involved-end -->
