### PR TITLE
fix(security): address review on elicitation credential flow

### DIFF
--- a/src/lib/elicit-credentials.ts
+++ b/src/lib/elicit-credentials.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ElicitResult } from "@modelcontextprotocol/sdk/types.js";
 import logger from "../logger.js";
 
 export interface CredentialField {
@@ -51,7 +52,7 @@ export async function elicitCredentialsIfSupported(
     };
   }
 
-  let result;
+  let result: ElicitResult;
   try {
     result = await server.server.elicitInput({
       mode: "form",
@@ -62,10 +63,12 @@ export async function elicitCredentialsIfSupported(
         required: missing.map((field) => field.key),
       },
     });
-  } catch (error) {
+  } catch {
     // A client that advertised elicitation but failed to handle it must not
-    // break the tool — fall back to whatever was provided.
-    logger.info(`Elicitation request failed; using provided values: ${error}`);
+    // break the tool — fall back to whatever was provided. The error is not
+    // logged: a client validation error can echo the submitted form values
+    // (including the password), which must never reach the logs.
+    logger.warn("Elicitation request failed; falling back to provided values.");
     return provided;
   }
 

--- a/src/tools/accessibility.ts
+++ b/src/tools/accessibility.ts
@@ -481,15 +481,11 @@ export default function addAccessibilityTools(
       username: z
         .string()
         .optional()
-        .describe(
-          "Site username. Omit to have it requested securely from the user.",
-        ),
+        .describe("Site username; omit to have it requested from the user."),
       password: z
         .string()
         .optional()
-        .describe(
-          "Site password. Omit to have it requested securely from the user; do not pass real passwords here.",
-        ),
+        .describe("Site password; omit to have it requested from the user."),
       usernameSelector: z
         .string()
         .optional()
@@ -504,39 +500,55 @@ export default function addAccessibilityTools(
         .describe("CSS selector for submit button (required for form auth)"),
     },
     async (args) => {
-      const creds = await elicitCredentialsIfSupported(
-        server,
-        { username: args.username, password: args.password },
-        [
-          {
-            key: "username",
-            title: "Site username",
-            description: `Username for the login being configured ("${args.name}")`,
-          },
-          {
-            key: "password",
-            title: "Site password",
-            description: `Password for the login being configured ("${args.name}")`,
-          },
-        ],
-        `Enter the login credentials for accessibility auth config "${args.name}".`,
-      );
+      try {
+        const creds = await elicitCredentialsIfSupported(
+          server,
+          { username: args.username, password: args.password },
+          [
+            {
+              key: "username",
+              title: "Site username",
+              description: `Username for the login being configured ("${args.name}")`,
+            },
+            {
+              key: "password",
+              title: "Site password",
+              description: `Password for the login being configured ("${args.name}")`,
+            },
+          ],
+          `Enter the login credentials for accessibility auth config "${args.name}".`,
+        );
 
-      if (!creds.username || !creds.password) {
-        return createErrorResponse(
-          "Username and password are required to create an auth config. Provide them when prompted, or pass them as arguments.",
+        if (!creds.username || !creds.password) {
+          const error = new Error(
+            "Username and password are required to create an auth config. Provide them when prompted, or pass them as arguments.",
+          );
+          trackMCP(
+            "createAccessibilityAuthConfig",
+            server.server.getClientVersion()!,
+            error,
+            config,
+          );
+          return createErrorResponse(error.message);
+        }
+
+        return await executeCreateAuthConfig(
+          {
+            ...args,
+            username: creds.username,
+            password: creds.password,
+          } as AuthConfigArgs,
+          server,
+          config,
+        );
+      } catch (error) {
+        return handleMCPError(
+          "createAccessibilityAuthConfig",
+          server,
+          config,
+          error,
         );
       }
-
-      return await executeCreateAuthConfig(
-        {
-          ...args,
-          username: creds.username,
-          password: creds.password,
-        } as AuthConfigArgs,
-        server,
-        config,
-      );
     },
   );
 

--- a/src/tools/testmanagement-utils/create-lca-steps.ts
+++ b/src/tools/testmanagement-utils/create-lca-steps.ts
@@ -25,18 +25,14 @@ export const CreateLCAStepsSchema = z.object({
     .boolean()
     .optional()
     .default(false)
-    .describe(
-      "Set true if the test case requires login. When true, credentials are requested securely from the user — prefer this over passing them.",
-    ),
+    .describe("Set true if the test case requires login."),
   credentials: z
     .object({
       username: z.string().describe("Username for authentication"),
       password: z.string().describe("Password for authentication"),
     })
     .optional()
-    .describe(
-      "Login credentials. Omit and set requires_authentication instead to have them requested securely from the user; passed here only as a fallback.",
-    ),
+    .describe("Login credentials; omit to have them requested from the user."),
   local_enabled: z
     .boolean()
     .optional()

--- a/src/tools/testmanagement.ts
+++ b/src/tools/testmanagement.ts
@@ -547,6 +547,19 @@ export async function createLCAStepsTool(
           ...args,
           credentials: { username: creds.username, password: creds.password },
         };
+      } else {
+        // requires_authentication was requested but no credentials could be
+        // obtained (client can't elicit, or the user declined). Fail clearly
+        // rather than creating a login test case with no credentials.
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Authentication is required for test case ${args.test_case_identifier}, but no credentials were provided. Provide them when prompted, or pass them as arguments.`,
+            },
+          ],
+          isError: true,
+        };
       }
     }
 

--- a/tests/tools/testmanagement.test.ts
+++ b/tests/tools/testmanagement.test.ts
@@ -725,7 +725,7 @@ describe("createLCAStepsTool", () => {
     expect(elicitInput).not.toHaveBeenCalled();
   });
 
-  it("falls back to the arg path (no elicit) when requires_authentication but the client cannot elicit", async () => {
+  it("errors (does not proceed) when requires_authentication but the client cannot elicit and no creds are passed", async () => {
     (createLCASteps as Mock).mockResolvedValue({ content: [], isError: false });
     const elicitInput = vi.fn();
     const localServer = {
@@ -737,10 +737,30 @@ describe("createLCAStepsTool", () => {
     } as any;
     const args = { ...validArgs, credentials: undefined, requires_authentication: true };
 
+    const result = await createLCAStepsTool(args as any, mockContext, mockConfig, localServer);
+
+    expect(elicitInput).not.toHaveBeenCalled();
+    // No login test case is created without credentials — it fails clearly.
+    expect(createLCASteps).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+  });
+
+  it("uses the credentials passed as args when requires_authentication is set (backward-compat)", async () => {
+    (createLCASteps as Mock).mockResolvedValue({ content: [], isError: false });
+    const elicitInput = vi.fn();
+    const localServer = {
+      server: {
+        getClientVersion: () => "test",
+        getClientCapabilities: () => ({}),
+        elicitInput,
+      },
+    } as any;
+    const args = { ...validArgs, requires_authentication: true }; // validArgs has credentials
+
     await createLCAStepsTool(args as any, mockContext, mockConfig, localServer);
 
     expect(elicitInput).not.toHaveBeenCalled();
-    expect(createLCASteps).toHaveBeenCalled();
+    expect(createLCASteps).toHaveBeenCalledWith(args, mockContext, mockConfig);
   });
 
   it("handles errors when creating LCA steps", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #361 (credential elicitation for `createAccessibilityAuthConfig` and `createLCASteps`), addressing review findings on the elicitation flow.

## Changes

- **Instrumentation gap** — `createAccessibilityAuthConfig` now fires `trackMCP` on the missing-credentials return path (previously untracked when the user declines or the client can't elicit), and the handler is wrapped in try/catch so a `getClientCapabilities()` failure routes through `handleMCPError` instead of throwing raw.
- **Silent failure in `createLCASteps`** — when `requires_authentication` is set but no credentials could be obtained (client can't elicit or the user declines), the tool now returns a clear error instead of silently creating a login test case with `credentials: undefined`. This mirrors the accessibility tool's behavior.
- **Log-leak hardening** — the elicitation fallback no longer logs the raw error (a client validation error can echo the submitted password); it logs a static `warn` instead.
- **Types** — the elicitation result is typed as `ElicitResult`.
- **Context budget** — trimmed the new `.describe()` strings back within the tool-prompt budget.

## Testing

- `npm run build` (lint + format + tests + tsc) — green (273 tests).
- Updated the `createLCASteps` test that had codified the silent behavior to assert the new error, and added a backward-compat test (credentials passed as args with `requires_authentication` set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
