### PR TITLE
chore: bump version to 1.2.36 in package.json, package-lock.json, and server.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserstack/mcp-server",
-      "version": "1.2.35",
+      "version": "1.2.36",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "description": "BrowserStack's Official MCP Server",
   "mcpName": "io.github.browserstack/mcp-server",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@browserstack/mcp-server",
-      "version": "1.2.35",
+      "version": "1.2.36",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bumps version 1.2.35 → 1.2.36 in `package.json`, `package-lock.json`, and `server.json` ahead of release. Follows the same pattern as #363.