### PR TITLE
fix: include per-region failure detail in TM connection error

### DIFF
--- a/src/lib/tm-base-url.ts
+++ b/src/lib/tm-base-url.ts
@@ -32,6 +32,8 @@ export async function getTMBaseURL(
   const authHeader =
     "Basic " + Buffer.from(`${username}:${password}`).toString("base64");
 
+  const failures: string[] = [];
+
   for (const baseUrl of TM_BASE_URLS) {
     try {
       const res = await apiClient.get({
@@ -39,6 +41,10 @@ export async function getTMBaseURL(
         headers: { Authorization: authHeader },
         raise_error: false,
       });
+
+      if (!res.ok) {
+        failures.push(`${baseUrl}: HTTP ${res.status}`);
+      }
 
       if (res.ok) {
         // Only populate the cache in single-tenant (stdio) mode; in remote mode
@@ -50,11 +56,13 @@ export async function getTMBaseURL(
         return baseUrl;
       }
     } catch (err) {
+      const code = (err as { code?: string })?.code ?? (err as Error)?.message;
+      failures.push(`${baseUrl}: ${code}`);
       logger.debug(`Failed TM base URL: ${baseUrl} (${err})`);
     }
   }
 
   throw new Error(
-    "Unable to connect to BrowserStack Test Management. Please check your credentials and network connection.Please open an issue on GitHub if the problem persists",
+    `Unable to connect to BrowserStack Test Management. Please check your credentials and network connection.Please open an issue on GitHub if the problem persists. Details: ${failures.join("; ")}`,
   );
 }

--- a/tests/lib/tm-base-url.test.ts
+++ b/tests/lib/tm-base-url.test.ts
@@ -67,3 +67,43 @@ describe("getTMBaseURL — multi-tenant cache discipline", () => {
     expect(apiClient.get).toHaveBeenCalledTimes(3);
   });
 });
+
+describe("getTMBaseURL — failure details", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports the HTTP status when requests complete (auth/permission failure)", async () => {
+    const { apiClient, getTMBaseURL } = await loadModule(false);
+    (apiClient.get as any).mockResolvedValue({ ok: false, status: 401 });
+
+    const err = (await getTMBaseURL(mockConfig).catch(
+      (e) => e as Error,
+    )) as unknown as Error;
+    expect(err.message).toMatch(/HTTP 401/);
+  });
+
+  it("reports the Node error code when requests never complete (network failure)", async () => {
+    const { apiClient, getTMBaseURL } = await loadModule(false);
+    (apiClient.get as any).mockRejectedValue(
+      Object.assign(new Error("self signed cert"), {
+        code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+      }),
+    );
+
+    const err = (await getTMBaseURL(mockConfig).catch(
+      (e) => e as Error,
+    )) as unknown as Error;
+    expect(err.message).toMatch(/UNABLE_TO_VERIFY_LEAF_SIGNATURE/);
+  });
+
+  it("passes through any other status verbatim (not just auth codes)", async () => {
+    const { apiClient, getTMBaseURL } = await loadModule(false);
+    (apiClient.get as any).mockResolvedValue({ ok: false, status: 503 });
+
+    const err = (await getTMBaseURL(mockConfig).catch(
+      (e) => e as Error,
+    )) as unknown as Error;
+    expect(err.message).toMatch(/HTTP 503/);
+  });
+});


### PR DESCRIPTION

The generic "check your credentials and network connection" was identical for auth failures, outages and network errors. Append each region's outcome: an HTTP status means the request completed (auth/permission), a Node error code means it did not (network, DNS, proxy, TLS).

Message prefix unchanged; detail is additive.