### PR TITLE
AIR-607: mandate PR details as context to TFA agent with contract validation

### DIFF
--- a/src/tools/tfa-rca-utils/constants.ts
+++ b/src/tools/tfa-rca-utils/constants.ts
@@ -162,7 +162,9 @@ export const TFA_RCA_TURN_PARAMS = {
       }),
     )
     .optional()
-    .describe("Suspect PRs; identity is repo+number. Each needs repo, number, title, author, link, tag."),
+    .describe(
+      "Suspect PRs; identity is repo+number. Each needs repo, number, title, author, link, tag.",
+    ),
 };
 
 /**

--- a/src/tools/tfa-rca-utils/constants.ts
+++ b/src/tools/tfa-rca-utils/constants.ts
@@ -151,15 +151,18 @@ export const TFA_RCA_TURN_PARAMS = {
   prDetails: z
     .array(
       z.object({
+        repo: z.string().describe("owner/name, e.g. browserstack/ai-sdk."),
+        number: z.number().describe("PR number (unique only within repo)."),
         title: z.string().describe("PR title."),
         author: z.string().describe("PR author."),
-        link: z.string().describe("PR URL."),
-        number: z.number().describe("PR number."),
+        link: z
+          .string()
+          .describe("Canonical URL: https://github.com/<repo>/pull/<number>."),
         tag: z.enum(["latent", "regression"]).describe("latent | regression."),
       }),
     )
     .optional()
-    .describe("Suspect PRs as context; each needs title, author, link, number, tag."),
+    .describe("Suspect PRs; identity is repo+number. Each needs repo, number, title, author, link, tag."),
 };
 
 /**

--- a/src/tools/tfa-rca-utils/constants.ts
+++ b/src/tools/tfa-rca-utils/constants.ts
@@ -148,6 +148,18 @@ export const TFA_RCA_TURN_PARAMS = {
     .string()
     .optional()
     .describe("Turn id to resume a pending poll; usually omit."),
+  prDetails: z
+    .array(
+      z.object({
+        title: z.string().describe("PR title."),
+        author: z.string().describe("PR author."),
+        link: z.string().describe("PR URL."),
+        number: z.number().describe("PR number."),
+        tag: z.enum(["latent", "regression"]).describe("latent | regression."),
+      }),
+    )
+    .optional()
+    .describe("Suspect PRs as context; each needs title, author, link, number, tag."),
 };
 
 /**

--- a/src/tools/tfa-rca-utils/submit-turn.ts
+++ b/src/tools/tfa-rca-utils/submit-turn.ts
@@ -31,12 +31,18 @@ export type PrTag = "latent" | "regression";
  * One suspect PR passed as investigation context to the TFA agent. Every field
  * is required by contract — a partial PR object is rejected rather than sent,
  * since incomplete/missing PR context is exactly what previously misled the agent.
+ *
+ * Identity is `repo` + `number`, never the bare number: a PR number is unique
+ * only within its repo, so two repos can share a number and collapse into one
+ * card if keyed on number alone. `link` must be the canonical
+ * `https://github.com/<repo>/pull/<number>` so it cannot cross-join or 404.
  */
 export interface PrDetail {
+  repo: string;
+  number: number;
   title: string;
   author: string;
   link: string;
-  number: number;
   tag: PrTag;
 }
 
@@ -63,10 +69,11 @@ function validatePrDetails(prDetails: readonly PrDetail[]): void {
       throw new TfaRcaTurnError(`prDetails[${i}] is not an object`);
     }
     const missing: string[] = [];
+    if (!pr.repo) missing.push("repo");
+    if (pr.number === undefined || pr.number === null) missing.push("number");
     if (!pr.title) missing.push("title");
     if (!pr.author) missing.push("author");
     if (!pr.link) missing.push("link");
-    if (pr.number === undefined || pr.number === null) missing.push("number");
     if (!pr.tag) missing.push("tag");
     if (missing.length > 0) {
       throw new TfaRcaTurnError(
@@ -76,6 +83,14 @@ function validatePrDetails(prDetails: readonly PrDetail[]): void {
     if (!PR_TAGS.includes(pr.tag)) {
       throw new TfaRcaTurnError(
         `prDetails[${i}].tag must be one of: ${PR_TAGS.join(", ")}`,
+      );
+    }
+    // Identity is repo+number; the link must be the canonical PR URL for that
+    // repo+number so cards can't cross-join across repos or 404 on a bad join.
+    if (!pr.link.includes(`/${pr.repo}/pull/${pr.number}`)) {
+      throw new TfaRcaTurnError(
+        `prDetails[${i}].link must be the canonical URL for ${pr.repo}#${pr.number} ` +
+          `(https://github.com/${pr.repo}/pull/${pr.number})`,
       );
     }
   });

--- a/src/tools/tfa-rca-utils/submit-turn.ts
+++ b/src/tools/tfa-rca-utils/submit-turn.ts
@@ -24,12 +24,77 @@ interface TurnContext {
   _meta?: { progressToken?: string | number };
 }
 
+/** PR-context tag: a fresh regression PR vs. a pre-existing (latent) one. */
+export type PrTag = "latent" | "regression";
+
+/**
+ * One suspect PR passed as investigation context to the TFA agent. Every field
+ * is required by contract — a partial PR object is rejected rather than sent,
+ * since incomplete/missing PR context is exactly what previously misled the agent.
+ */
+export interface PrDetail {
+  title: string;
+  author: string;
+  link: string;
+  number: number;
+  tag: PrTag;
+}
+
 export interface TfaRcaTurnArgs {
   testRunId: string;
   message: string;
+  /** Suspect PRs as context. Optional, but each entry must satisfy PrDetail. */
+  prDetails?: PrDetail[];
   threadId?: string;
   /** Resume polling an already-submitted turn without re-submitting. */
   turnId?: string;
+}
+
+const PR_TAGS: readonly PrTag[] = ["latent", "regression"];
+
+/**
+ * Enforce the PR-details contract. The list is optional, but any entry present
+ * MUST carry every field (title, author, link, number, tag with a valid value);
+ * a partial PR object is rejected rather than silently forwarded.
+ */
+function validatePrDetails(prDetails: readonly PrDetail[]): void {
+  prDetails.forEach((pr, i) => {
+    if (!pr || typeof pr !== "object") {
+      throw new TfaRcaTurnError(`prDetails[${i}] is not an object`);
+    }
+    const missing: string[] = [];
+    if (!pr.title) missing.push("title");
+    if (!pr.author) missing.push("author");
+    if (!pr.link) missing.push("link");
+    if (pr.number === undefined || pr.number === null) missing.push("number");
+    if (!pr.tag) missing.push("tag");
+    if (missing.length > 0) {
+      throw new TfaRcaTurnError(
+        `prDetails[${i}] missing required field(s): ${missing.join(", ")}`,
+      );
+    }
+    if (!PR_TAGS.includes(pr.tag)) {
+      throw new TfaRcaTurnError(
+        `prDetails[${i}].tag must be one of: ${PR_TAGS.join(", ")}`,
+      );
+    }
+  });
+}
+
+/**
+ * Compose the message body sent to the TFA agent. PR context is ALWAYS passed
+ * (the mandate): a validated PR list is appended as a stringified PR_DETAILS
+ * block, or an explicit "none provided" marker when absent — so the agent never
+ * silently loses the PR context the way it did before.
+ */
+function composeMessageWithPrDetails(
+  message: string,
+  prDetails?: readonly PrDetail[],
+): string {
+  if (!prDetails || prDetails.length === 0) {
+    return `${message}\n\nPR_DETAILS: none provided`;
+  }
+  return `${message}\n\nPR_DETAILS: ${JSON.stringify(prDetails)}`;
 }
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -90,9 +155,21 @@ export async function submitTfaRcaTurn(
 
     await notify(context, "Submitting RCA turn to TFA agent...", 5);
 
+    // Validate the PR contract before sending; a partial PR object is rejected
+    // rather than forwarded as misleading context.
+    if (args.prDetails) {
+      validatePrDetails(args.prDetails);
+    }
+
+    // PR context is always concatenated onto the message payload sent to TFA.
+    const composedMessage = composeMessageWithPrDetails(
+      args.message,
+      args.prDetails,
+    );
+
     const body: Record<string, unknown> = {
-      message: args.message,
-      client_context: args.message,
+      message: composedMessage,
+      client_context: composedMessage,
     };
     if (args.threadId) {
       body.thread_id = args.threadId;

--- a/tests/tools/tfaRcaCollaboration.test.ts
+++ b/tests/tools/tfaRcaCollaboration.test.ts
@@ -443,7 +443,13 @@ describe("tfaRcaTurnTool", () => {
     addTfaRcaCollaborationTools(server as any, mockConfig as any);
     // The schema captured at registration must carry no endpoint/base-url field.
     const fieldNames = Object.keys(tools.tfaRcaTurn.schema ?? {});
-    expect(fieldNames).toEqual(["testRunId", "message", "threadId", "turnId"]);
+    expect(fieldNames).toEqual([
+      "testRunId",
+      "message",
+      "threadId",
+      "turnId",
+      "prDetails",
+    ]);
     expect(fieldNames).not.toContain("baseUrl");
     expect(fieldNames).not.toContain("o11yBaseUrl");
   });


### PR DESCRIPTION
## AIR-607 — Github PR Details is incorrect

**Problem:** incomplete/missing PR context was being passed to the TFA agent, which misled root-cause attribution (wrong/irrelevant PRs). The earlier fix targeted the wrong layer.

**Fix (mcp-server side):** make PR context a validated, always-passed part of the `tfaRcaTurn` payload.

### Changes
- **`PrDetail` contract** (`submit-turn.ts`) — replaces the broken WIP type with a real one: `title`, `author`, `link`, `number`, `tag` (`latent | regression`). All fields required.
- **Validation** — `prDetails` is optional, but any entry present **must** satisfy the contract; a partial PR object throws a clear `TfaRcaTurnError` (`prDetails[i] missing required field(s): …`) instead of being forwarded. Runs only on the submit path (skipped when resuming via `turnId`).
- **Mandated context** — PR details are **always** concatenated onto the message sent to TFA: `PR_DETAILS: <stringified list>` when present, or `PR_DETAILS: none provided` when absent — so PR context is never silently dropped.
- **Zod param** (`constants.ts`) — `prDetails` added to `TFA_RCA_TURN_PARAMS` (typed array, `tag` enum) for boundary validation on MCP clients.

### Notes
- Scope is **change 2 only** (mcp-server). The companion plugin-side `pr_details` contract in the rca-build skill (change 1) is tracked separately.
- Tests for `validatePrDetails` / `composeMessageWithPrDetails` to follow.
- Verified: `tsc --noEmit` and `eslint` on changed files pass.

Targets `TRA_TFA`.