### PR TITLE
docs: note hosted Remote MCP server is now stateless (Streamable HTTP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Click on the buttons below to install MCP in your respective IDE:
 
 <a href="http://mcp.browserstack.com/one-click-setup?client=vscode"><img src="assets/one-click-vs-code.png" alt="Install in VS Code" width="160" height="80"></a>&nbsp;&nbsp;&nbsp;<a href="http://mcp.browserstack.com/one-click-setup?client=cursor"><img src="assets/one-click-cursor.png" alt="Install in Cursor" width="150" height="70"></a>
 
+> **Note:** The hosted Remote MCP server (`mcp.browserstack.com`) is now fully stateless over Streamable HTTP — any Streamable-HTTP client (Claude, Cursor, VS Code, ChatGPT) connects with no configuration change.
+
 #### Note : Ensure you are using Node version >= `18.0` 
 - Check your node version using `node --version`. Recommended version: `v22.15.0` (LTS)
 - To Upgrade Node :


### PR DESCRIPTION
## What

One-line README note announcing that the **hosted Remote MCP server** (`mcp.browserstack.com`) now runs **fully stateless over Streamable HTTP**.

## Why

The Remote MCP server dropped its legacy HTTP+SSE transport, the `Mcp-Session-Id` header, and Redis (both deprecated by the MCP spec on 2026-07-28). There are **no code changes to this package** — this docs-only PR exists so the change surfaces in `@browserstack/mcp-server` release notes for users of the hosted endpoint.

Any Streamable-HTTP client (Claude, Cursor, VS Code, ChatGPT) connects with no configuration change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)