### PR TITLE
Add the tm capability index

### DIFF
--- a/capability/tm.capability-index.json
+++ b/capability/tm.capability-index.json
@@ -1,0 +1,19793 @@
+{
+  "schema_version": 1,
+  "version": "1.0",
+  "build_id": "83525474_2026-09-02T12:13:05Z",
+  "tm": {
+    "summary": "BrowserStack Test Management API (v1 — the SSO/OAuth app API, session-authenticated).",
+    "capabilities": [
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/assign",
+        "mode": "write",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true,
+            "example": "TR-14"
+          }
+        ],
+        "body": [
+          {
+            "name": "owner",
+            "type": "integer",
+            "description": "The ID of the user to assign as the owner of the test run."
+          }
+        ],
+        "intent": "Assign a owner to the test run",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "active_state",
+          "assignee_imported",
+          "created_at",
+          "description",
+          "environment",
+          "is_automation",
+          "is_dynamic",
+          "observability_url",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestRunWriteResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-cases/bulk-archive",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "q",
+            "type": "object",
+            "description": "SCOPE for `select_all` — the same filter shape as `V2SearchQueryRequest.q` (see the search-and-filter flow), sent as a SIBLING of `test_case`, not inside it. With `select_all: true` the server resolves the target set from this `q` (plus `folder_id`) and ignores `ids`; with `select_all: false` it is unused. DANGER, verified live: an unrecognised key here is SILENTLY DROPPED, so a typo widens the ta"
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "description": "SOURCE folder to scope the selection to, at top level. Merged into the search scope and it OVERWRITES `q.folder_id` when both are present. Do not confuse it with the DESTINATION, which for move lives at `test_case.destination_folder_id` and for copy at top-level `destination_folder_id`."
+          },
+          {
+            "name": "p",
+            "type": "integer",
+            "description": "Page of the scoped view, as the UI sends it. Only consulted when `select_all` is true and no `q` is present (the unfiltered folder-count path)."
+          },
+          {
+            "name": "include_subfolders_tc",
+            "type": "boolean",
+            "description": "Extend the selection into subfolders of `folder_id`. Compared as the string `true`. The UI sets it for consolidated (non-folder) views."
+          },
+          {
+            "name": "ids",
+            "type": "array",
+            "required": true,
+            "description": "Integer ids of the cases to archive / retrieve.",
+            "json_path": "/test_case/ids"
+          },
+          {
+            "name": "de_selected_ids",
+            "type": "array",
+            "required": true,
+            "description": "Ids to exclude when `select_all` is true.",
+            "json_path": "/test_case/de_selected_ids"
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "required": true,
+            "description": "Apply to every case in scope, minus `de_selected_ids`.",
+            "json_path": "/test_case/select_all"
+          }
+        ],
+        "intent": "Bulk Archive Test Cases",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "BulkArchiveResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-plans/bulk-archive",
+        "mode": "write",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "test_plan_ids",
+            "type": "array",
+            "required": true,
+            "description": "Plan INTEGER ids."
+          }
+        ],
+        "intent": "Archive test plans in bulk (reversible — prefer this over delete)",
+        "returns": [
+          "async",
+          "unique_id"
+        ],
+        "responses": {
+          "200": {
+            "description": "Sync: `{success, plans, count}`. Async (above threshold):\n`{success, async: true, unique_id}`.\n",
+            "schema": {
+              "$schema": "V1TestPlanBulkResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/test-cases/bulk_assign",
+        "mode": "write",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true,
+            "example": "TR-14"
+          }
+        ],
+        "query": [
+          {
+            "name": "include_subfolders_tc",
+            "type": "boolean"
+          }
+        ],
+        "body": [
+          {
+            "name": "assignee_id",
+            "type": "integer",
+            "example": 2,
+            "description": "ID of the assignee to whom the test cases will be assigned"
+          },
+          {
+            "name": "mapping_ids",
+            "type": "array",
+            "example": [
+              999,
+              991,
+              1024,
+              1019
+            ],
+            "description": "List of test case IDs to be linked"
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "example": false,
+            "description": "Flag to select all test cases"
+          },
+          {
+            "name": "de_selected_ids",
+            "type": "array",
+            "description": "List of test case IDs to be de-selected"
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "description": "ID of the folder to which the test cases belong"
+          }
+        ],
+        "intent": "Bulk assign test cases to a test run",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully assigned test cases to the test run",
+            "schema": {
+              "$schema": "TestCaseListResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-cases/bulk-copy",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "q",
+            "type": "object",
+            "description": "SCOPE for `select_all` — the same filter shape as `V2SearchQueryRequest.q` (see the search-and-filter flow), sent as a SIBLING of `test_case`, not inside it. With `select_all: true` the server resolves the target set from this `q` (plus `folder_id`) and ignores `ids`; with `select_all: false` it is unused. DANGER, verified live: an unrecognised key here is SILENTLY DROPPED, so a typo widens the ta"
+          },
+          {
+            "name": "p",
+            "type": "integer",
+            "description": "Page of the scoped view, as the UI sends it. Only consulted when `select_all` is true and no `q` is present (the unfiltered folder-count path)."
+          },
+          {
+            "name": "include_subfolders_tc",
+            "type": "boolean",
+            "description": "Extend the selection into subfolders of `folder_id`. Compared as the string `true`. The UI sets it for consolidated (non-folder) views."
+          },
+          {
+            "name": "ids",
+            "type": "array",
+            "required": true,
+            "json_path": "/test_case/ids"
+          },
+          {
+            "name": "de_selected_ids",
+            "type": "array",
+            "required": true,
+            "json_path": "/test_case/de_selected_ids"
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "required": true,
+            "json_path": "/test_case/select_all"
+          },
+          {
+            "name": "folder_id",
+            "type": "string",
+            "description": "SOURCE folder that scopes the selection, at top level. OPTIONAL when you pass explicit `ids` (verified live: the copy succeeds without it), but send it whenever `select_all` is true — it is what bounds the set, and `select_all` with `folder_id` and no `q` copies exactly that folder's cases. Integer and string are both accepted; the declared string matches what the UI sends here, which unlike bulk-"
+          },
+          {
+            "name": "destination_folder_id",
+            "type": "integer",
+            "required": true,
+            "description": "Target folder for the copies, and the one genuinely required destination field — omitting it is a bare `400`, verified live. NOTE it is TOP-LEVEL for copy, unlike bulk-move where the destination sits inside `test_case`."
+          },
+          {
+            "name": "destination_project_id",
+            "type": "string",
+            "description": "Target project id. Needed only for a copy to ANOTHER project. For a copy WITHIN one project it is OPTIONAL — verified live, omitting it copies correctly into `destination_folder_id`, and integer and string are both accepted. The product does both: its Copy/Move modal sends the source project id, its clone / drag-and-drop path omits it. Send the source id to be explicit or omit it; never invent a v"
+          }
+        ],
+        "intent": "Bulk copy test cases",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "BulkCopyTestCasesResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-cases/bulk-delete",
+        "mode": "destructive",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "q",
+            "type": "object",
+            "description": "SCOPE for `select_all` — the same filter shape as `V2SearchQueryRequest.q` (see the search-and-filter flow), sent as a SIBLING of `test_case`, not inside it. With `select_all: true` the server resolves the target set from this `q` (plus `folder_id`) and ignores `ids`; with `select_all: false` it is unused. DANGER, verified live: an unrecognised key here is SILENTLY DROPPED, so a typo widens the ta"
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "description": "SOURCE folder to scope the selection to, at top level. Merged into the search scope and it OVERWRITES `q.folder_id` when both are present. Do not confuse it with the DESTINATION, which for move lives at `test_case.destination_folder_id` and for copy at top-level `destination_folder_id`."
+          },
+          {
+            "name": "p",
+            "type": "integer",
+            "description": "Page of the scoped view, as the UI sends it. Only consulted when `select_all` is true and no `q` is present (the unfiltered folder-count path)."
+          },
+          {
+            "name": "include_subfolders_tc",
+            "type": "boolean",
+            "description": "Extend the selection into subfolders of `folder_id`. Compared as the string `true`. The UI sets it for consolidated (non-folder) views."
+          },
+          {
+            "name": "ids",
+            "type": "array",
+            "required": true,
+            "description": "Integer ids of the cases to delete.",
+            "json_path": "/test_case/ids"
+          },
+          {
+            "name": "de_selected_ids",
+            "type": "array",
+            "required": true,
+            "description": "Ids to exclude when `select_all` is true.",
+            "json_path": "/test_case/de_selected_ids"
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "required": true,
+            "description": "Delete every case in scope, minus `de_selected_ids`.",
+            "json_path": "/test_case/select_all"
+          }
+        ],
+        "intent": "Bulk Delete Test Cases from Search",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "BulkDeleteTestCasesResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-results/bulk-delete",
+        "mode": "destructive",
+        "entity": "result",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "result_ids",
+            "type": "array",
+            "required": true,
+            "description": "Result INTEGER ids. Non-empty, max 300."
+          }
+        ],
+        "intent": "Delete test results in bulk — PARTIAL SUCCESS is normal, always read `skipped`",
+        "returns": [
+          "id",
+          "reason"
+        ],
+        "responses": {
+          "200": {
+            "description": "Partial success is normal — `deleted_ids` is what actually went, `skipped` is what\ndid not (usually authorisation).\n",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "result": {
+                  "type": "object",
+                  "description": "Both lists are nested HERE, not at the top level. Reading\nresponse[\"deleted_ids\"] directly finds nothing and makes a successful\ndelete look like a no-op.\n",
+                  "properties": {
+                    "deleted_ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      }
+                    },
+                    "skipped": {
+                      "type": "array",
+                      "description": "Entries are OBJECTS, not bare ids — {\"id\": 13, \"reason\": \"not_found\"}.\nCommon reasons: not_found, or the caller is neither author nor project admin.\n",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`result_ids` missing or empty."
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "422": {
+            "description": "More than 300 ids in one request."
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-cases/bulk-edit",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "q",
+            "type": "object",
+            "description": "SCOPE for `select_all` — the same filter shape as `V2SearchQueryRequest.q` (see the search-and-filter flow), sent as a SIBLING of `test_case`, not inside it. With `select_all: true` the server resolves the target set from this `q` (plus `folder_id`) and ignores `ids`; with `select_all: false` it is unused. DANGER, verified live: an unrecognised key here is SILENTLY DROPPED, so a typo widens the ta"
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "description": "SOURCE folder to scope the selection to, at top level. Merged into the search scope and it OVERWRITES `q.folder_id` when both are present. Do not confuse it with the DESTINATION, which for move lives at `test_case.destination_folder_id` and for copy at top-level `destination_folder_id`."
+          },
+          {
+            "name": "p",
+            "type": "integer",
+            "description": "Page of the scoped view, as the UI sends it. Only consulted when `select_all` is true and no `q` is present (the unfiltered folder-count path)."
+          },
+          {
+            "name": "include_subfolders_tc",
+            "type": "boolean",
+            "description": "Extend the selection into subfolders of `folder_id`. Compared as the string `true`. The UI sets it for consolidated (non-folder) views."
+          },
+          {
+            "name": "ids",
+            "type": "array",
+            "required": true,
+            "description": "Integer ids of the cases to edit.",
+            "json_path": "/test_case/ids"
+          },
+          {
+            "name": "de_selected_ids",
+            "type": "array",
+            "description": "Ids to exclude when `select_all` is true.",
+            "json_path": "/test_case/de_selected_ids"
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "description": "Apply to every case in scope, minus `de_selected_ids`.",
+            "json_path": "/test_case/select_all"
+          },
+          {
+            "name": "automation_status",
+            "type": "string",
+            "json_path": "/test_case/automation_status"
+          },
+          {
+            "name": "case_type",
+            "type": "integer",
+            "json_path": "/test_case/case_type"
+          },
+          {
+            "name": "custom_fields",
+            "type": "object",
+            "required": true,
+            "description": "Map of custom-field id to value. ALWAYS SEND THIS KEY — pass `{}` when changing no custom fields. Omitting it returns 500 (the server dereferences a nil hash), the same defect as on PATCH .../test-cases.",
+            "json_path": "/test_case/custom_fields"
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "json_path": "/test_case/issues"
+          },
+          {
+            "name": "owner",
+            "type": "integer",
+            "description": "TM user id.",
+            "json_path": "/test_case/owner"
+          },
+          {
+            "name": "preconditions",
+            "type": "string",
+            "json_path": "/test_case/preconditions"
+          },
+          {
+            "name": "priority",
+            "type": "integer",
+            "json_path": "/test_case/priority"
+          },
+          {
+            "name": "status",
+            "type": "integer",
+            "json_path": "/test_case/status"
+          },
+          {
+            "name": "tags",
+            "type": "array",
+            "description": "REPLACES the entire tag list on every selected case. Read the existing tags and send the union if you mean to add.",
+            "json_path": "/test_case/tags"
+          }
+        ],
+        "intent": "Bulk Update Test Cases",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Bulk test case update accepted and queued for processing",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "test_cases": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "TestCase"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/test-cases/edit",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true,
+            "example": "TR-14"
+          }
+        ],
+        "query": [
+          {
+            "name": "include_subfolders_tc",
+            "type": "boolean"
+          },
+          {
+            "name": "status_id",
+            "type": "integer"
+          }
+        ],
+        "body": [
+          {
+            "name": "attachments",
+            "type": "array",
+            "example": []
+          },
+          {
+            "name": "de_selected_ids",
+            "type": "array",
+            "example": []
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "example": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">something</span></p>",
+            "description": "HTML formatted comment or note"
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "example": 21
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "example": []
+          },
+          {
+            "name": "mapping_ids",
+            "type": "array",
+            "example": [
+              999,
+              991,
+              1024,
+              1019
+            ]
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "example": false
+          },
+          {
+            "name": "status_id",
+            "type": "integer",
+            "example": 21
+          },
+          {
+            "name": "test_run_ids",
+            "type": "array",
+            "example": [
+              1001,
+              1002,
+              1003
+            ],
+            "description": "Array of BTCER IDs to apply the bulk edit to (passed when automation = true)"
+          },
+          {
+            "name": "test_case_counts",
+            "type": "array",
+            "example": [
+              1,
+              3,
+              2
+            ],
+            "description": "Array of test case counts corresponding to each BTCER ID in test_run_ids (passed when automation = true)"
+          }
+        ],
+        "intent": "Bulk edit test cases result in test run",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully updated test cases in the test run",
+            "schema": {
+              "$schema": "TestCaseListResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "PATCH",
+        "path": "/api/v1/projects/{project_id}/test-cases",
+        "mode": "write",
+        "entity": "tag",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "q",
+            "type": "object",
+            "description": "SCOPE for `select_all` — the same filter shape as `V2SearchQueryRequest.q` (see the search-and-filter flow), sent as a SIBLING of `test_case`, not inside it. With `select_all: true` the server resolves the target set from this `q` (plus `folder_id`) and ignores `ids`; with `select_all: false` it is unused. DANGER, verified live: an unrecognised key here is SILENTLY DROPPED, so a typo widens the ta"
+          },
+          {
+            "name": "p",
+            "type": "integer",
+            "description": "Page of the scoped view, as the UI sends it. Only consulted when `select_all` is true and no `q` is present (the unfiltered folder-count path)."
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "description": "Optional scope hint when editing within one folder."
+          },
+          {
+            "name": "include_subfolders_tc",
+            "type": "boolean",
+            "description": "With `folder_id`, also include cases in its subfolders."
+          },
+          {
+            "name": "ids",
+            "type": "array",
+            "required": true,
+            "description": "Integer ids of the cases to edit. One id is fine — this endpoint is also the cleanest way to add/remove a tag on a single case.",
+            "json_path": "/test_case/ids"
+          },
+          {
+            "name": "de_selected_ids",
+            "type": "array",
+            "description": "Ids to exclude when `select_all` is true.",
+            "json_path": "/test_case/de_selected_ids"
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "description": "Apply to every case in scope, minus `de_selected_ids`.",
+            "json_path": "/test_case/select_all"
+          },
+          {
+            "name": "tags",
+            "type": "string",
+            "description": "Tag names. Supports `add` / `remove` — use those rather than `replace` unless the intent really is to discard the existing tags.",
+            "fields": [
+              {
+                "name": "operation",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "value",
+                "type": "array"
+              }
+            ],
+            "json_path": "/test_case/tags"
+          },
+          {
+            "name": "issues",
+            "type": "string",
+            "description": "Linked issues; each value item is `{issue_id, issue_type}`. Supports `add` / `remove`.",
+            "fields": [
+              {
+                "name": "operation",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "value",
+                "type": "array"
+              }
+            ],
+            "json_path": "/test_case/issues"
+          },
+          {
+            "name": "custom_fields",
+            "type": "object",
+            "required": true,
+            "description": "Keyed by custom-field id (numeric string), each entry `{\"value\": …, \"operation\": …}`. Collection-valued custom fields support `add` / `remove`; scalar ones take `replace` / `empty`.\nALWAYS SEND THIS KEY, even when changing no custom fields — pass `{}`. Omitting it makes the server dereference a nil hash and return 500 (`undefined method 'each' for nil`). The server's own request validator wrongly ",
+            "json_path": "/test_case/custom_fields"
+          },
+          {
+            "name": "priority",
+            "type": "string",
+            "fields": [
+              {
+                "name": "operation",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "value",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_case/priority"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "fields": [
+              {
+                "name": "operation",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "value",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_case/status"
+          },
+          {
+            "name": "case_type",
+            "type": "string",
+            "fields": [
+              {
+                "name": "operation",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "value",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_case/case_type"
+          },
+          {
+            "name": "automation_state",
+            "type": "string",
+            "fields": [
+              {
+                "name": "operation",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "value",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_case/automation_state"
+          },
+          {
+            "name": "automation_status",
+            "type": "string",
+            "description": "Legacy internal_name string alias for `automation_state`.",
+            "fields": [
+              {
+                "name": "operation",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "value",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_case/automation_status"
+          },
+          {
+            "name": "owner",
+            "type": "string",
+            "description": "TM user id (`users[].id` from GET .../users-v2), not browserstack_user_id.",
+            "fields": [
+              {
+                "name": "operation",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "value",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_case/owner"
+          },
+          {
+            "name": "preconditions",
+            "type": "string",
+            "description": "Text value.",
+            "fields": [
+              {
+                "name": "operation",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "value",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_case/preconditions"
+          },
+          {
+            "name": "review_status",
+            "type": "string",
+            "fields": [
+              {
+                "name": "operation",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "value",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_case/review_status"
+          },
+          {
+            "name": "reviewers",
+            "type": "string",
+            "description": "Reviewer TM user ids. Only honoured on a Team-Pro workspace with review-approve enabled.",
+            "fields": [
+              {
+                "name": "operation",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "value",
+                "type": "array"
+              }
+            ],
+            "json_path": "/test_case/reviewers"
+          }
+        ],
+        "intent": "Bulk edit test cases with per-field add / remove / replace operations (PREFERRED bulk write).",
+        "returns": [
+          "async",
+          "unique_id"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Cases updated, or accepted asynchronously above the threshold.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "async": {
+                  "type": "boolean",
+                  "description": "Present and true when the selection exceeded the sync threshold."
+                },
+                "unique_id": {
+                  "type": "string",
+                  "description": "Async job id — poll/re-read to confirm (see `async-jobs`)."
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-cases/bulk-move",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "q",
+            "type": "object",
+            "description": "SCOPE for `select_all` — the same filter shape as `V2SearchQueryRequest.q` (see the search-and-filter flow), sent as a SIBLING of `test_case`, not inside it. With `select_all: true` the server resolves the target set from this `q` (plus `folder_id`) and ignores `ids`; with `select_all: false` it is unused. DANGER, verified live: an unrecognised key here is SILENTLY DROPPED, so a typo widens the ta"
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "description": "SOURCE folder to scope the selection to, at top level. Merged into the search scope and it OVERWRITES `q.folder_id` when both are present. Do not confuse it with the DESTINATION, which for move lives at `test_case.destination_folder_id` and for copy at top-level `destination_folder_id`."
+          },
+          {
+            "name": "p",
+            "type": "integer",
+            "description": "Page of the scoped view, as the UI sends it. Only consulted when `select_all` is true and no `q` is present (the unfiltered folder-count path)."
+          },
+          {
+            "name": "include_subfolders_tc",
+            "type": "boolean",
+            "description": "Extend the selection into subfolders of `folder_id`. Compared as the string `true`. The UI sets it for consolidated (non-folder) views."
+          },
+          {
+            "name": "ids",
+            "type": "array",
+            "required": true,
+            "description": "Integer ids of the cases to move.",
+            "json_path": "/test_case/ids"
+          },
+          {
+            "name": "de_selected_ids",
+            "type": "array",
+            "required": true,
+            "description": "Ids to exclude when `select_all` is true.",
+            "json_path": "/test_case/de_selected_ids"
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "required": true,
+            "description": "Move every case in scope, minus `de_selected_ids`.",
+            "json_path": "/test_case/select_all"
+          },
+          {
+            "name": "destination_folder_id",
+            "type": "integer",
+            "description": "Target folder id. Falls back to `folder_id` when omitted.",
+            "json_path": "/test_case/destination_folder_id"
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "description": "Legacy alias for `destination_folder_id`, used only when that is absent.",
+            "json_path": "/test_case/folder_id"
+          },
+          {
+            "name": "destination_project_id",
+            "type": "integer",
+            "description": "Set only for a cross-project move. Shared cases cannot be moved across projects (422).",
+            "json_path": "/test_case/destination_project_id"
+          }
+        ],
+        "intent": "Bulk Move Test Cases",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "BulkMoveTestCasesResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-cases/bulk-retrieve",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "q",
+            "type": "object",
+            "description": "SCOPE for `select_all` — the same filter shape as `V2SearchQueryRequest.q` (see the search-and-filter flow), sent as a SIBLING of `test_case`, not inside it. With `select_all: true` the server resolves the target set from this `q` (plus `folder_id`) and ignores `ids`; with `select_all: false` it is unused. DANGER, verified live: an unrecognised key here is SILENTLY DROPPED, so a typo widens the ta"
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "description": "SOURCE folder to scope the selection to, at top level. Merged into the search scope and it OVERWRITES `q.folder_id` when both are present. Do not confuse it with the DESTINATION, which for move lives at `test_case.destination_folder_id` and for copy at top-level `destination_folder_id`."
+          },
+          {
+            "name": "p",
+            "type": "integer",
+            "description": "Page of the scoped view, as the UI sends it. Only consulted when `select_all` is true and no `q` is present (the unfiltered folder-count path)."
+          },
+          {
+            "name": "include_subfolders_tc",
+            "type": "boolean",
+            "description": "Extend the selection into subfolders of `folder_id`. Compared as the string `true`. The UI sets it for consolidated (non-folder) views."
+          },
+          {
+            "name": "ids",
+            "type": "array",
+            "required": true,
+            "description": "Integer ids of the cases to archive / retrieve.",
+            "json_path": "/test_case/ids"
+          },
+          {
+            "name": "de_selected_ids",
+            "type": "array",
+            "required": true,
+            "description": "Ids to exclude when `select_all` is true.",
+            "json_path": "/test_case/de_selected_ids"
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "required": true,
+            "description": "Apply to every case in scope, minus `de_selected_ids`.",
+            "json_path": "/test_case/select_all"
+          }
+        ],
+        "intent": "Bulk Retrieve Test Cases",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Bulk test case retrieval succeeded (async or sync)",
+            "schema": {
+              "$schema": "TestCaseListResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-plans/bulk-retrieve",
+        "mode": "write",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "test_plan_ids",
+            "type": "array",
+            "required": true,
+            "description": "Plan INTEGER ids."
+          }
+        ],
+        "intent": "Un-archive test plans in bulk (undo bulk-archive)",
+        "returns": [
+          "async",
+          "unique_id"
+        ],
+        "responses": {
+          "200": {
+            "description": "Sync: `{success, plans, count}`. Async (above threshold):\n`{success, async: true, unique_id}`.\n",
+            "schema": {
+              "$schema": "V1TestPlanBulkResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions/{session_id}/clone",
+        "mode": "write",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Clone an exploratory session (async when it has many logs).",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-plans/{test_plan_id}/clone",
+        "mode": "write",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_plan_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "Name for the clone. Defaults to a server-generated copy name.",
+            "json_path": "/test_plan/name"
+          },
+          {
+            "name": "copy_all_sub_plans",
+            "type": "boolean",
+            "json_path": "/test_plan/copy_all_sub_plans"
+          },
+          {
+            "name": "sub_plan_ids",
+            "type": "array",
+            "description": "Clone only these sub-plans. Ignored when copy_all_sub_plans is true.",
+            "json_path": "/test_plan/sub_plan_ids"
+          }
+        ],
+        "intent": "Clone a test plan, optionally with its sub-plans",
+        "responses": {
+          "200": {
+            "description": "The cloned plan.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/clone",
+        "mode": "write",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true,
+            "example": "TR-14"
+          }
+        ],
+        "body": [
+          {
+            "name": "copy_tc_assignee",
+            "type": "boolean",
+            "description": "Copy test case assignees from the original run"
+          },
+          {
+            "name": "copy_issues",
+            "type": "boolean",
+            "description": "Copy issues linked to the original run"
+          },
+          {
+            "name": "copy_tags",
+            "type": "boolean",
+            "description": "Copy tags from the original run"
+          },
+          {
+            "name": "copy_all_cases",
+            "type": "boolean",
+            "description": "Include all test cases in the cloned run"
+          },
+          {
+            "name": "status",
+            "type": "array",
+            "example": [
+              "passed",
+              "failed"
+            ],
+            "description": "Status strings to filter test cases to copy"
+          },
+          {
+            "name": "status_id",
+            "type": "array",
+            "example": [
+              1,
+              2
+            ],
+            "description": "Status IDs to filter test cases to copy"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "example": "Cloned Test Run - 2025",
+            "description": "Name for the new cloned test run"
+          }
+        ],
+        "intent": "Clone a test run",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "active_state",
+          "assignee_imported",
+          "created_at",
+          "description",
+          "environment",
+          "is_automation",
+          "is_dynamic",
+          "observability_url",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestRunResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions/{session_id}/close",
+        "mode": "write",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "type": "integer",
+            "required": true,
+            "example": 123
+          }
+        ],
+        "intent": "Close an exploratory session",
+        "responses": {
+          "200": {
+            "description": "Exploratory session closed successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/close",
+        "mode": "write",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true,
+            "example": "TR-14"
+          }
+        ],
+        "intent": "Close a test run",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "active_state",
+          "assignee_imported",
+          "created_at",
+          "description",
+          "environment",
+          "is_automation",
+          "is_dynamic",
+          "observability_url",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestRunWriteResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folders/copy",
+        "mode": "write",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "source_folder_id",
+            "type": "integer",
+            "required": true,
+            "example": 2,
+            "description": "ID of folder to copy"
+          },
+          {
+            "name": "destination_folder_id",
+            "type": "integer",
+            "required": true,
+            "example": 3,
+            "description": "ID of destination parent folder"
+          },
+          {
+            "name": "destination_project_id",
+            "type": "integer",
+            "required": true,
+            "example": 10000,
+            "description": "Destination project ID (can be same or different)"
+          },
+          {
+            "name": "async",
+            "type": "boolean",
+            "example": true,
+            "description": "Whether to process asynchronously via background job"
+          },
+          {
+            "name": "copy_test_cases",
+            "type": "boolean",
+            "example": true,
+            "description": "Whether to copy test cases within folder"
+          }
+        ],
+        "intent": "Copy a folder to another location",
+        "returns": [
+          "async",
+          "folder_id",
+          "unique_id"
+        ],
+        "responses": {
+          "200": {
+            "$response": "FolderCopyResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs/selection-count",
+        "mode": "read",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "example": false,
+            "description": "Select every case in the project.",
+            "json_path": "/selection/select_all"
+          },
+          {
+            "name": "unique_test_case_count",
+            "type": "integer",
+            "example": 2,
+            "json_path": "/selection/unique_test_case_count"
+          },
+          {
+            "name": "folders",
+            "type": "object",
+            "description": "Map of folder id (as a string key) to that folder's selection.",
+            "json_path": "/selection/folders"
+          },
+          {
+            "name": "shared_selection",
+            "type": "object",
+            "description": "Map of project ids to their shared test-case selection, same inner shape as `selection`."
+          },
+          {
+            "name": "configurations",
+            "type": "array",
+            "required": true,
+            "example": [],
+            "description": "Configuration ids. Required — pass an empty array if there are none."
+          },
+          {
+            "name": "trtc_configuration_mappings",
+            "type": "array",
+            "description": "Per-configuration case mappings. An ARRAY of objects — the server rejects an object here.",
+            "fields": [
+              {
+                "name": "configuration_id",
+                "type": "integer"
+              },
+              {
+                "name": "select_all",
+                "type": "boolean"
+              },
+              {
+                "name": "linked_test_cases",
+                "type": "array"
+              },
+              {
+                "name": "unlinked_test_cases",
+                "type": "array"
+              }
+            ]
+          }
+        ],
+        "intent": "Count the test cases a selection resolves to (incl. configurations/datasets).",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "Count.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "count": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/bulk-test-cases",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "test_cases",
+            "type": "array",
+            "required": true,
+            "description": "One UNWRAPPED item per case (no per-item `test_case` key), ≤10. Send `template` on each item — bulk defaults to `test_case_text`, unlike single create. See the operation description.",
+            "fields": [
+              {
+                "name": "name",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "test_case_folder_id",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "attachments",
+                "type": "array"
+              },
+              {
+                "name": "automation_state",
+                "type": "integer"
+              },
+              {
+                "name": "automation_status",
+                "type": "string"
+              },
+              {
+                "name": "case_type",
+                "type": "integer"
+              },
+              {
+                "name": "custom_fields",
+                "type": "object"
+              },
+              {
+                "name": "description",
+                "type": "string"
+              },
+              {
+                "name": "estimate",
+                "type": "string"
+              },
+              {
+                "name": "estimated_duration_seconds",
+                "type": "integer"
+              },
+              {
+                "name": "expected_result",
+                "type": "string"
+              },
+              {
+                "name": "is_dataset_modified",
+                "type": "boolean"
+              },
+              {
+                "name": "issues",
+                "type": "array"
+              },
+              {
+                "name": "owner",
+                "type": "integer"
+              },
+              {
+                "name": "preconditions",
+                "type": "string"
+              },
+              {
+                "name": "priority",
+                "type": "integer"
+              },
+              {
+                "name": "review_status",
+                "type": "string"
+              },
+              {
+                "name": "reviewers",
+                "type": "array"
+              },
+              {
+                "name": "send_for_review",
+                "type": "boolean"
+              },
+              {
+                "name": "shared_precondition_id",
+                "type": "integer"
+              },
+              {
+                "name": "status",
+                "type": "integer"
+              },
+              {
+                "name": "tags",
+                "type": "array"
+              },
+              {
+                "name": "template",
+                "type": "string"
+              },
+              {
+                "name": "template_id",
+                "type": "integer"
+              },
+              {
+                "name": "template_step_type",
+                "type": "string"
+              },
+              {
+                "name": "test_case_dataset",
+                "type": "string"
+              },
+              {
+                "name": "test_case_steps",
+                "type": "array"
+              }
+            ]
+          },
+          {
+            "name": "unique_id",
+            "type": "string",
+            "description": "Client-supplied idempotency key. When present and the group has the async bulk-create feature flag enabled, the request is processed asynchronously and acknowledged with 202; completion is delivered over the common WebSocket channel keyed by this id."
+          }
+        ],
+        "intent": "Create test cases in bulk for a folder (≤10) — the call to use for more than one case.",
+        "returns": [
+          "request_trace_id"
+        ],
+        "responses": {
+          "200": {
+            "description": "Test cases created successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "test_cases": {
+                      "type": "array",
+                      "items": {
+                        "$schema": "TestCase"
+                      }
+                    },
+                    "path_folders": {
+                      "type": "array",
+                      "items": {
+                        "$schema": "Folder"
+                      }
+                    },
+                    "request_trace_id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted for asynchronous processing (feature-flag gated; requires unique_id). Completion is broadcast on common_channel_<bs_user_id> with operation bulk_create and the echoed unique_id.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "async": {
+                  "type": "boolean"
+                },
+                "unique_id": {
+                  "type": "string"
+                },
+                "scenario_name": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "integer"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/configurations",
+        "mode": "write",
+        "entity": "configuration",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Create a new configuration for a project",
+        "returns": [
+          "id",
+          "name",
+          "created_at",
+          "group_id",
+          "is_suggested",
+          "record_status"
+        ],
+        "responses": {
+          "200": {
+            "description": "Configuration successfully created",
+            "schema": {
+              "$schema": "Configuration"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/admin-v2/settings/custom-fields/{custom_fields_id}/datasets/{dataset_id}/options",
+        "mode": "write",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "dataset_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "custom_fields_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "option_value",
+            "type": "string",
+            "required": true,
+            "description": "The option label."
+          },
+          {
+            "name": "is_default",
+            "type": "boolean",
+            "required": true,
+            "description": "REQUIRED — a missing value is a 400. Must be false for every option of a multi_dropdown; at most one true for a dropdown."
+          },
+          {
+            "name": "parent_option_id",
+            "type": "integer",
+            "description": "For nested_dropdown children only — the parent option this hangs under."
+          }
+        ],
+        "intent": "Add one option to a dataset — how you add a dropdown value.",
+        "responses": {
+          "200": {
+            "description": "The created option under `data`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/admin-v2/settings/custom-fields/{custom_fields_id}/datasets",
+        "mode": "write",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "custom_fields_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "linked_projects",
+            "type": "array",
+            "description": "Project INTEGER ids this dataset applies to. This is what makes the field visible in a project — a dataset with no linked projects leaves the field invisible everywhere. NOTE the spelling differs from the project-mappings endpoint, which uses `link_projects` / `unlink_projects`."
+          },
+          {
+            "name": "link_to_future_projects",
+            "type": "boolean",
+            "description": "Auto-link projects created later."
+          },
+          {
+            "name": "linked_to_all_projects",
+            "type": "boolean",
+            "description": "Apply to every project in the workspace."
+          },
+          {
+            "name": "options",
+            "type": "array",
+            "description": "The allowed values, for dropdown-style fields.",
+            "fields": [
+              {
+                "name": "option_value",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "is_default",
+                "type": "boolean",
+                "required": true
+              },
+              {
+                "name": "parent_option_id",
+                "type": "integer"
+              }
+            ]
+          }
+        ],
+        "intent": "Add a dataset (an option set + its project links) to an existing field.",
+        "responses": {
+          "200": {
+            "description": "The created dataset under `data`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/admin-v2/settings/custom-fields",
+        "mode": "write",
+        "entity": "custom_field",
+        "body": [
+          {
+            "name": "field_name",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "field_type",
+            "type": "string",
+            "required": true,
+            "values": [
+              "string",
+              "text",
+              "user",
+              "dropdown",
+              "multi_dropdown",
+              "url",
+              "boolean",
+              "int",
+              "date",
+              "nested_dropdown"
+            ],
+            "description": "Data type. Use THIS vocabulary — the legacy `field_*` spellings (e.g. `field_dropdown`) are a different API's and are rejected. Silently immutable after creation: an update that changes it returns 200 and changes nothing."
+          },
+          {
+            "name": "entity_type",
+            "type": "string",
+            "values": [
+              "TestCase",
+              "TestResult",
+              "TestPlan",
+              "ExploratorySession"
+            ],
+            "description": "Which entity the field hangs off. One field belongs to exactly one."
+          },
+          {
+            "name": "is_required",
+            "type": "boolean",
+            "required": true,
+            "description": "REQUIRED, and must be a literal boolean — omitting it is a 400."
+          },
+          {
+            "name": "datasets",
+            "type": "array",
+            "required": true,
+            "description": "REQUIRED for every field type, dropdown or not — omitting it is a 400. Carries the options and the project scope. Send one entry with `linked_projects` set.",
+            "fields": [
+              {
+                "name": "linked_projects",
+                "type": "array"
+              },
+              {
+                "name": "link_to_future_projects",
+                "type": "boolean"
+              },
+              {
+                "name": "linked_to_all_projects",
+                "type": "boolean"
+              },
+              {
+                "name": "options",
+                "type": "array"
+              }
+            ]
+          },
+          {
+            "name": "place_holder_text",
+            "type": "string"
+          },
+          {
+            "name": "default_value",
+            "type": "string",
+            "description": "Only honoured when `field_type` is `boolean`."
+          },
+          {
+            "name": "levels",
+            "type": "array",
+            "description": "REQUIRED when field_type is `nested_dropdown`, minimum 2 entries, each {name, level_type}."
+          }
+        ],
+        "intent": "Create a custom field DEFINITION (workspace-admin action).",
+        "responses": {
+          "200": {
+            "description": "The created definition under `data` (`id`, `field_name`, `field_type`,\n`is_required`). Options are NOT included — verify via `form-fields-v2`.\n",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/datasets",
+        "mode": "write",
+        "entity": "dataset",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "description": "Name of the dataset.",
+            "json_path": "/dataset/name"
+          },
+          {
+            "name": "variables",
+            "type": "array",
+            "required": true,
+            "description": "List of dataset variables/columns (max 40).",
+            "fields": [
+              {
+                "name": "name",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "uuid",
+                "type": "string"
+              }
+            ],
+            "json_path": "/dataset/variables"
+          },
+          {
+            "name": "rows",
+            "type": "array",
+            "required": true,
+            "description": "List of dataset rows (max 100).",
+            "fields": [
+              {
+                "name": "row_number",
+                "type": "integer",
+                "required": true
+              },
+              {
+                "name": "row_data",
+                "type": "array",
+                "required": true
+              },
+              {
+                "name": "uuid",
+                "type": "string"
+              }
+            ],
+            "json_path": "/dataset/rows"
+          }
+        ],
+        "intent": "Create a new dataset.",
+        "returns": [
+          "name",
+          "created_at",
+          "rows_count",
+          "uuid"
+        ],
+        "responses": {
+          "200": {
+            "description": "Dataset created successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "description": "Indicates if the dataset was created successfully.",
+                  "example": true
+                },
+                "dataset": {
+                  "$schema": "Dataset"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions",
+        "mode": "write",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "title",
+            "type": "string",
+            "required": true,
+            "example": "Checkout flow exploration",
+            "description": "Title of the exploratory session.",
+            "json_path": "/exploratory_session/title"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "example": "Explore edge cases in the checkout flow.",
+            "description": "Optional description.",
+            "json_path": "/exploratory_session/description"
+          },
+          {
+            "name": "charter",
+            "type": "string",
+            "example": "Focus on payment error handling",
+            "description": "Testing charter describing the scope and goals.",
+            "json_path": "/exploratory_session/charter"
+          },
+          {
+            "name": "timebox_duration",
+            "type": "integer",
+            "example": 60,
+            "description": "Planned duration in minutes.",
+            "json_path": "/exploratory_session/timebox_duration"
+          },
+          {
+            "name": "owner",
+            "type": "integer",
+            "example": 42,
+            "description": "TCM user ID of the session owner / assignee.",
+            "json_path": "/exploratory_session/owner"
+          },
+          {
+            "name": "assignee",
+            "type": "integer",
+            "example": 42,
+            "description": "Alias for `owner`. TCM user ID of the assignee.",
+            "json_path": "/exploratory_session/assignee"
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "example": 456,
+            "description": "ID of the folder to place this session in.",
+            "json_path": "/exploratory_session/folder_id"
+          },
+          {
+            "name": "tags",
+            "type": "array",
+            "example": [
+              "regression",
+              "mobile"
+            ],
+            "description": "Tags for the session.",
+            "json_path": "/exploratory_session/tags"
+          },
+          {
+            "name": "configurations",
+            "type": "array",
+            "example": [
+              1,
+              3
+            ],
+            "description": "Configuration IDs to associate with this session.",
+            "json_path": "/exploratory_session/configurations"
+          },
+          {
+            "name": "attachments",
+            "type": "array",
+            "example": [
+              101,
+              102
+            ],
+            "description": "Blob / media attachment IDs.",
+            "json_path": "/exploratory_session/attachments"
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "description": "Issues to link to this session.",
+            "fields": [
+              {
+                "name": "issue_id",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "issue_type",
+                "type": "string",
+                "required": true
+              }
+            ],
+            "json_path": "/exploratory_session/issues"
+          }
+        ],
+        "intent": "Create an exploratory session",
+        "returns": [
+          "id",
+          "title",
+          "actual_duration",
+          "charter",
+          "created_at",
+          "description",
+          "duration",
+          "folder_id",
+          "session_log_count",
+          "session_state",
+          "timebox_duration",
+          "updated_at"
+        ],
+        "responses": {
+          "201": {
+            "description": "Exploratory session created successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "exploratory_session": {
+                  "$schema": "ExploratorySession"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions/{session_id}/logs",
+        "mode": "write",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "type": "integer",
+            "required": true,
+            "example": 123
+          }
+        ],
+        "body": [
+          {
+            "name": "content",
+            "type": "string",
+            "example": "<p>Tapped checkout button — spinner appeared but order was not created.</p>",
+            "description": "Rich-text HTML content of the log entry.",
+            "json_path": "/session_log/content"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "values": [
+              "pass",
+              "fail",
+              "bug",
+              "retest",
+              "block",
+              "note"
+            ],
+            "example": "fail",
+            "description": "Test result status for this log step.",
+            "json_path": "/session_log/status"
+          },
+          {
+            "name": "elapsed_time",
+            "type": "integer",
+            "example": 120,
+            "description": "Time elapsed for this step in seconds.",
+            "json_path": "/session_log/elapsed_time"
+          },
+          {
+            "name": "defects",
+            "type": "array",
+            "description": "Defects to link to this log entry.",
+            "fields": [
+              {
+                "name": "issue_id",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "issue_type",
+                "type": "string",
+                "required": true
+              }
+            ],
+            "json_path": "/session_log/defects"
+          }
+        ],
+        "intent": "Create a session log entry",
+        "returns": [
+          "id",
+          "status",
+          "content",
+          "created_at",
+          "elapsed_time",
+          "session_id",
+          "updated_at"
+        ],
+        "responses": {
+          "201": {
+            "description": "Session log created successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "session_log": {
+                  "$schema": "ExploratorySessionLog"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/filter",
+        "mode": "write",
+        "entity": "filter",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "description": "Name of the filter"
+          },
+          {
+            "name": "entity",
+            "type": "string",
+            "required": true,
+            "values": [
+              "testcase",
+              "testplan",
+              "testrun",
+              "exploratory_session",
+              "test_plan_test_case"
+            ],
+            "description": "Entity type the filter applies to. The server's validator accepts five values (the\nlast two were missing here); an unlisted value returns 400 \"Invalid JSON data\"."
+          },
+          {
+            "name": "is_project_level",
+            "type": "boolean",
+            "description": "Whether this filter is available at project level"
+          },
+          {
+            "name": "filters",
+            "type": "object",
+            "required": true,
+            "description": "Filter criteria object containing the actual filter conditions"
+          }
+        ],
+        "intent": "Create a new filter",
+        "returns": [
+          "id",
+          "name",
+          "created_at",
+          "entity_type",
+          "is_project_level",
+          "owner",
+          "project_id",
+          "updated_at"
+        ],
+        "responses": {
+          "200": {
+            "$response": "FilterCreateResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects",
+        "mode": "write",
+        "entity": "project",
+        "body": [
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "json_path": "/project/name"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "json_path": "/project/description"
+          }
+        ],
+        "intent": "Create a new project.",
+        "returns": [
+          "name",
+          "description"
+        ],
+        "responses": {
+          "200": {
+            "description": "Project created successfully.",
+            "schema": {
+              "$schema": "ProjectCreateRequest"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/reports",
+        "mode": "write",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "projectId",
+            "type": "integer",
+            "example": 10000
+          },
+          {
+            "name": "report_type",
+            "type": "string",
+            "required": true,
+            "values": [
+              "Test Run Summary",
+              "Test Run Detailed Report",
+              "Test Plan Summary",
+              "Requirement Traceability Report",
+              "Test Case Activity",
+              "Exploratory Session Summary",
+              "User Workload Report",
+              "Defects Summary",
+              "Defects Detailed Report"
+            ],
+            "example": "Test Run Summary",
+            "description": "Report type, sent as its DISPLAY NAME (not a machine slug).\n\nSeven types produce data. `Defects Summary` and `Defects Detailed Report` are\naccepted on create/update but have no data branch on the server, so such a report\nalways reads back with `report_data: null` — never offer them as a way to report\non defects (use `Test Run Summary`, whose sections include `issues_by_priority` /\n`issues_by_statu"
+          },
+          {
+            "name": "title",
+            "type": "string",
+            "example": "Weekly Test Case Activity"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "example": "Testing"
+          },
+          {
+            "name": "report_timeframe",
+            "type": "string",
+            "required": true,
+            "values": [
+              "last_one_day",
+              "last_one_week",
+              "last_one_month",
+              "last_three_months",
+              "custom",
+              "specific_test_runs",
+              "specific_test_plans",
+              "specific_test_cases",
+              "specific_sessions",
+              "requirements"
+            ],
+            "example": "last_one_week",
+            "description": "The window a report covers. Also the value of the `reportTimeRange` query param\non the report-detail read.\n\nThe four relative windows compute a date range from \"now\". `custom` computes it\nfrom `custom_date_range` and **requires** that field — sending `custom` without it\nis an unhandled server error, not a 422.\n\nThe five remaining values carry no dates; they select entities through\n`report_filters`"
+          },
+          {
+            "name": "report_creation_mode",
+            "type": "string",
+            "required": true,
+            "values": [
+              "custom_report",
+              "system_generated"
+            ],
+            "example": "custom_report",
+            "description": "`system_generated` is the one-click report the product creates for you;\n`custom_report` is a user-configured one. For a Requirement Traceability\nreport, `system_generated` makes the server auto-populate\n`report_filters.requirements` with every requirement in the project."
+          },
+          {
+            "name": "test_run",
+            "type": "object",
+            "fields": [
+              {
+                "name": "created_at",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "status",
+                "type": "array",
+                "required": true
+              },
+              {
+                "name": "owner",
+                "type": "array",
+                "required": true
+              },
+              {
+                "name": "automation_status",
+                "type": "array",
+                "required": true
+              },
+              {
+                "name": "type",
+                "type": "array",
+                "required": true
+              }
+            ],
+            "json_path": "/dynamic_filters/test_run"
+          },
+          {
+            "name": "status",
+            "type": "array",
+            "json_path": "/report_filters/status"
+          },
+          {
+            "name": "priority",
+            "type": "array",
+            "json_path": "/report_filters/priority"
+          },
+          {
+            "name": "case_type",
+            "type": "array",
+            "json_path": "/report_filters/case_type"
+          },
+          {
+            "name": "assignee",
+            "type": "array",
+            "json_path": "/report_filters/assignee"
+          },
+          {
+            "name": "automation_status",
+            "type": "array",
+            "json_path": "/report_filters/automation_status"
+          },
+          {
+            "name": "automation_state",
+            "type": "array",
+            "json_path": "/report_filters/automation_state"
+          },
+          {
+            "name": "test_runs",
+            "type": "array",
+            "description": "Integer run ids — pairs with report_timeframe=specific_test_runs.",
+            "json_path": "/report_filters/test_runs"
+          },
+          {
+            "name": "test_plans",
+            "type": "array",
+            "description": "Integer plan ids — pairs with report_timeframe=specific_test_plans.",
+            "json_path": "/report_filters/test_plans"
+          },
+          {
+            "name": "test_cases",
+            "type": "string",
+            "description": "Case selection — pairs with report_timeframe=specific_test_cases. FOLDER-KEYED\n(see SelectionData), never a flat id list: the server resolves the selection\nthrough its folder map, so any other shape yields zero cases and saves an\nUNSCOPED, project-wide report at 200.\n\nSend all three keys. Folder ids are STRING keys; test-case ids are INTEGERS\n(the numeric `id`, not the TC-NNN identifier) — take bo",
+            "fields": [
+              {
+                "name": "select_all",
+                "type": "boolean",
+                "required": true
+              },
+              {
+                "name": "folders",
+                "type": "object",
+                "required": true
+              },
+              {
+                "name": "unique_test_case_count",
+                "type": "integer",
+                "required": true
+              }
+            ],
+            "json_path": "/report_filters/test_cases"
+          },
+          {
+            "name": "session_ids",
+            "type": "array",
+            "description": "Exploratory session ids — pairs with report_timeframe=specific_sessions.",
+            "json_path": "/report_filters/session_ids"
+          },
+          {
+            "name": "requirements",
+            "type": "object",
+            "description": "{ issue_type: [issue_id, ...] } — pairs with report_timeframe=requirements.",
+            "json_path": "/report_filters/requirements"
+          },
+          {
+            "name": "test_plan_selection",
+            "type": "object",
+            "description": "Per-plan sub-plan selection: { plan_id: { select_all, selected_sub_plan_ids, deselected_sub_plan_ids } }.",
+            "json_path": "/report_filters/test_plan_selection"
+          },
+          {
+            "name": "builds",
+            "type": "array",
+            "json_path": "/report_filters/builds"
+          },
+          {
+            "name": "projects",
+            "type": "array",
+            "json_path": "/report_filters/projects"
+          },
+          {
+            "name": "folder",
+            "type": "array",
+            "json_path": "/report_filters/folder"
+          },
+          {
+            "name": "test_case_tags",
+            "type": "array",
+            "json_path": "/report_filters/test_case_tags"
+          },
+          {
+            "name": "tc_custom_fields",
+            "type": "object",
+            "description": "Keyed by custom-field id (an OBJECT, not an array). ONLY consumed for\n`Test Run Summary`, `Test Run Detailed Report` and `Test Case Activity` — on\nthe other six report types the server never reads it and drops it silently.\nPersisted (and read back) under the name `custom_fields`.",
+            "json_path": "/report_filters/tc_custom_fields"
+          },
+          {
+            "name": "custom_date_range",
+            "type": "string",
+            "example": "2025-04-16 2025-04-24",
+            "description": "\"YYYY-MM-DD YYYY-MM-DD\" (space-separated). REQUIRED whenever report_timeframe is `custom`."
+          },
+          {
+            "name": "users",
+            "type": "array",
+            "json_path": "/mail_to/users"
+          },
+          {
+            "name": "external_mails",
+            "type": "array",
+            "json_path": "/mail_to/external_mails"
+          },
+          {
+            "name": "frequency",
+            "type": "string",
+            "values": [
+              "daily",
+              "weekly",
+              "monthly"
+            ],
+            "example": "weekly",
+            "description": "Scheduling cadence. Send `frequency` and `frequency_details` TOGETHER, or omit\nBOTH — omitting both creates a valid unscheduled, on-demand report.\n\nTwo consequences of omitting them: `mail_to` is only persisted for scheduled\nreports (recipients on an unscheduled report are silently dropped), and\n`next_run_at` stays null.\n\nThere is no `once` value — the server's cadence enum is daily/weekly/monthly"
+          },
+          {
+            "name": "time",
+            "type": "string",
+            "example": "08:00",
+            "description": "24-hour HH:MM, UTC.",
+            "json_path": "/frequency_details/time"
+          },
+          {
+            "name": "day",
+            "type": "string",
+            "example": "monday",
+            "description": "Required for weekly (lowercase day name) and monthly (integer 1-28).\nOmit for daily.",
+            "json_path": "/frequency_details/day"
+          }
+        ],
+        "intent": "Create a new scheduled report for a project",
+        "returns": [
+          "id",
+          "identifier",
+          "title",
+          "created_at",
+          "custom_date_range",
+          "description",
+          "frequency",
+          "group_id",
+          "next_run_at",
+          "project_id",
+          "report_creation_mode",
+          "report_timeframe"
+        ],
+        "responses": {
+          "201": {
+            "$response": "CreateReportResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folders",
+        "mode": "write",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "example": "Root Folder A",
+            "description": "Name of the root folder"
+          },
+          {
+            "name": "notes",
+            "type": "string",
+            "example": "This folder contains all regression test cases",
+            "description": "Optional notes or description for the folder"
+          }
+        ],
+        "intent": "Create a root-level folder for test cases in a project",
+        "returns": [
+          "id",
+          "name",
+          "cases_count",
+          "group_id",
+          "is_automation",
+          "project_id",
+          "sub_folders_count",
+          "total_cases_count"
+        ],
+        "responses": {
+          "200": {
+            "$response": "RootFolderDetailsResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/shared-steps",
+        "mode": "write",
+        "entity": "shared_step",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "title",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "description": "ID of the shared-field folder to place the shared step in. Null or omitted means the root (Unassigned)."
+          },
+          {
+            "name": "shared_step_details",
+            "type": "array",
+            "required": true,
+            "fields": [
+              {
+                "name": "order",
+                "type": "integer",
+                "required": true
+              },
+              {
+                "name": "step",
+                "type": "string"
+              },
+              {
+                "name": "result",
+                "type": "string"
+              },
+              {
+                "name": "test_data",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "intent": "Create a new shared step in a project",
+        "returns": [
+          "id",
+          "title",
+          "step_count",
+          "test_case_count"
+        ],
+        "responses": {
+          "201": {
+            "$response": "SharedStepsPostResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/test-cases/{test_case_id}/step/{step_id}",
+        "mode": "write",
+        "entity": "result",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "step_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "status_id",
+            "type": "integer",
+            "json_path": "/test_run_step_result/status_id"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "json_path": "/test_run_step_result/description"
+          }
+        ],
+        "intent": "Record a per-step result for a case in a run (v1).",
+        "responses": {
+          "200": {
+            "description": "Recorded step result.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/mkdir",
+        "mode": "write",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "description": "Name of the new folder.",
+            "json_path": "/folder/name"
+          },
+          {
+            "name": "notes",
+            "type": "string",
+            "description": "Description of the new folder.",
+            "json_path": "/folder/notes"
+          }
+        ],
+        "intent": "create subfolder inside a specific folder",
+        "returns": [
+          "id",
+          "name",
+          "cases_count",
+          "group_id",
+          "is_automation",
+          "project_id",
+          "sub_folders_count",
+          "total_cases_count"
+        ],
+        "responses": {
+          "200": {
+            "description": "Folder created successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "folder": {
+                      "$schema": "Folder"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-cases",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Create the FIRST test case in a project that has no folders (needs create_at_root).",
+        "returns": [
+          "result",
+          "step"
+        ],
+        "responses": {
+          "200": {
+            "description": "Test case successfully created",
+            "schema": {
+              "$schema": "TestCase"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "test_case",
+            "type": "object",
+            "required": true,
+            "fields": [
+              {
+                "name": "name",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "test_case_folder_id",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "attachments",
+                "type": "array"
+              },
+              {
+                "name": "automation_state",
+                "type": "integer"
+              },
+              {
+                "name": "automation_status",
+                "type": "string"
+              },
+              {
+                "name": "case_type",
+                "type": "integer"
+              },
+              {
+                "name": "custom_fields",
+                "type": "object"
+              },
+              {
+                "name": "description",
+                "type": "string"
+              },
+              {
+                "name": "estimate",
+                "type": "string"
+              },
+              {
+                "name": "estimated_duration_seconds",
+                "type": "integer"
+              },
+              {
+                "name": "expected_result",
+                "type": "string"
+              },
+              {
+                "name": "is_dataset_modified",
+                "type": "boolean"
+              },
+              {
+                "name": "issues",
+                "type": "array"
+              },
+              {
+                "name": "owner",
+                "type": "integer"
+              },
+              {
+                "name": "preconditions",
+                "type": "string"
+              },
+              {
+                "name": "priority",
+                "type": "integer"
+              },
+              {
+                "name": "review_status",
+                "type": "string"
+              },
+              {
+                "name": "reviewers",
+                "type": "array"
+              },
+              {
+                "name": "send_for_review",
+                "type": "boolean"
+              },
+              {
+                "name": "shared_precondition_id",
+                "type": "integer"
+              },
+              {
+                "name": "status",
+                "type": "integer"
+              },
+              {
+                "name": "tags",
+                "type": "array"
+              },
+              {
+                "name": "template",
+                "type": "string"
+              },
+              {
+                "name": "template_id",
+                "type": "integer"
+              },
+              {
+                "name": "template_step_type",
+                "type": "string"
+              },
+              {
+                "name": "test_case_dataset",
+                "type": "string"
+              },
+              {
+                "name": "test_case_steps",
+                "type": "array"
+              }
+            ]
+          },
+          {
+            "name": "create_at_root",
+            "type": "boolean"
+          }
+        ],
+        "intent": "Create test cases for a folder in a project.",
+        "returns": [
+          "id",
+          "name",
+          "cases_count",
+          "group_id",
+          "is_automation",
+          "project_id",
+          "sub_folders_count",
+          "total_cases_count"
+        ],
+        "responses": {
+          "200": {
+            "description": "Test cases created successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "test_case": {
+                  "$schema": "TestCase"
+                },
+                "project_id": {
+                  "$schema": "Project"
+                },
+                "folder_id": {
+                  "$schema": "Folder"
+                },
+                "path_folders": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "Folder"
+                  }
+                },
+                "success": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-plans",
+        "mode": "write",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "name",
+            "type": "string",
+            "json_path": "/test_plan/name"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "json_path": "/test_plan/description"
+          },
+          {
+            "name": "start_date",
+            "type": "string",
+            "description": "ISO-8601 date.",
+            "json_path": "/test_plan/start_date"
+          },
+          {
+            "name": "end_date",
+            "type": "string",
+            "description": "ISO-8601 date.",
+            "json_path": "/test_plan/end_date"
+          },
+          {
+            "name": "plan_status",
+            "type": "string",
+            "description": "Plan status. The list filter accepts new / started / completed.",
+            "json_path": "/test_plan/plan_status"
+          },
+          {
+            "name": "owner",
+            "type": "integer",
+            "description": "Owner user id — resolve via the project users read first.",
+            "json_path": "/test_plan/owner"
+          },
+          {
+            "name": "parent_plan_id",
+            "type": "integer",
+            "description": "Parent plan's INTEGER id. Set it to create (or re-parent into) a SUB-plan — the\nresult carries an STP-NNN identifier. Null/omitted means a top-level plan.",
+            "json_path": "/test_plan/parent_plan_id"
+          },
+          {
+            "name": "tags",
+            "type": "array",
+            "json_path": "/test_plan/tags"
+          },
+          {
+            "name": "reviewers",
+            "type": "array",
+            "description": "Reviewer user ids.",
+            "json_path": "/test_plan/reviewers"
+          },
+          {
+            "name": "attachments",
+            "type": "array",
+            "description": "Attachment ids already uploaded via the attachments surface.",
+            "json_path": "/test_plan/attachments"
+          },
+          {
+            "name": "custom_fields",
+            "type": "object",
+            "json_path": "/test_plan/custom_fields"
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "description": "Linked tracker issues. Structured — NOT a flat array of keys.",
+            "fields": [
+              {
+                "name": "issue_id",
+                "type": "string"
+              },
+              {
+                "name": "issue_type",
+                "type": "string"
+              },
+              {
+                "name": "metadata",
+                "type": "object"
+              }
+            ],
+            "json_path": "/test_plan/issues"
+          },
+          {
+            "name": "test_runs",
+            "type": "string",
+            "description": "The plan's linked test runs. Accepts EITHER an array of test-run integer ids, OR a\nbulk-selection object for \"every run matching this filter\". On update this REPLACES\nthe existing link set rather than appending.",
+            "json_path": "/test_plan/test_runs"
+          }
+        ],
+        "intent": "Create a test plan — or a SUB-plan, by setting parent_plan_id",
+        "responses": {
+          "200": {
+            "description": "The created plan. `identifier` is the `TP-NNN` (or `STP-NNN` for a sub-plan).",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/test-cases/{test_case_id}/test-results",
+        "mode": "write",
+        "entity": "result",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true,
+            "example": "TR-14"
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "status_id",
+            "type": "integer",
+            "description": "Result status id — resolve the name (\"Passed\", \"Failed\") to an id first; this field takes the id. Effectively required, though a missing value is accepted and leaves the result unstatused.",
+            "json_path": "/test_result/status_id"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "json_path": "/test_result/description"
+          },
+          {
+            "name": "custom_fields",
+            "type": "object",
+            "json_path": "/test_result/custom_fields"
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "description": "Linked defects. Each entry is an OBJECT — a bare string is silently dropped by the server's parameter filter, so the issue link is never created and no error is returned.",
+            "fields": [
+              {
+                "name": "issue_id",
+                "type": "string"
+              },
+              {
+                "name": "issue_type",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_result/issues"
+          },
+          {
+            "name": "attachments",
+            "type": "array",
+            "json_path": "/test_result/attachments"
+          },
+          {
+            "name": "elapsed_time",
+            "type": "integer",
+            "json_path": "/test_result/elapsed_time"
+          },
+          {
+            "name": "configuration_id",
+            "type": "integer",
+            "description": "Which configuration this result is for. TOP level — the server does not read it from inside `test_result`, so nesting it silently logs the result against the default configuration."
+          },
+          {
+            "name": "mapping_id",
+            "type": "integer",
+            "description": "Target a specific run/case mapping. Top level."
+          },
+          {
+            "name": "test_case_count",
+            "type": "integer",
+            "description": "Total number of test cases linked to the automation execution"
+          }
+        ],
+        "intent": "Create a new test result for a test case in a test run",
+        "returns": [
+          "id",
+          "status",
+          "backtrace",
+          "configuration_id",
+          "created_at",
+          "created_by_imported",
+          "custom_fields",
+          "description",
+          "error_description",
+          "expanded",
+          "failure_type",
+          "finished_at"
+        ],
+        "responses": {
+          "201": {
+            "$response": "TestResultCreateResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs",
+        "mode": "write",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "filters",
+            "type": "object",
+            "example": {
+              "priority": [
+                "High"
+              ],
+              "folder_ids": [
+                105
+              ]
+            },
+            "description": "Forward-sync rule for a DYNAMIC run, at the TOP level of the body — not inside `test_run`. This does NOT select cases: it never back-fills existing ones, so a create whose only case-bearing key is `filters` returns 200 with an EMPTY run. Use `test_case_ids` or `selection` to put cases in the run, and send `filters` only in addition, when the user asked the run to stay in sync.\nSending a non-empty "
+          },
+          {
+            "name": "dynamic_filter",
+            "type": "object",
+            "example": {
+              "owner": [],
+              "status": [],
+              "priority": []
+            },
+            "description": "Filter criteria (backward compatible format - use `filters` instead). Top level, same as `filters`, including that it selects no cases and flips the run dynamic."
+          },
+          {
+            "name": "test_case_ids",
+            "type": "array",
+            "example": [
+              2336
+            ]
+          },
+          {
+            "name": "auto_assign",
+            "type": "boolean"
+          },
+          {
+            "name": "shared_selection",
+            "type": "object",
+            "description": "Selection of cases shared in from other projects. Top level, same as `selection`."
+          },
+          {
+            "name": "run_state",
+            "type": "string",
+            "required": true,
+            "values": [
+              "new_run",
+              "in_progress",
+              "under_review",
+              "rejected",
+              "done",
+              "closed"
+            ],
+            "example": "new_run",
+            "description": "MANDATORY. The v1 endpoint validates this against the enum and hard-rejects anything else (including a missing key) with `400 \"invalid data\"`. Use `new_run` for a freshly created run. Note: v2 defaulted this to `new_run` server-side; v1 does NOT.",
+            "json_path": "/test_run/run_state"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "example": "Regression – Login",
+            "json_path": "/test_run/name"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "example": "",
+            "json_path": "/test_run/description"
+          },
+          {
+            "name": "owner",
+            "type": "integer",
+            "example": 2,
+            "description": "TM user id of the run owner. Unresolvable ids are silently treated as unassigned rather than erroring.",
+            "json_path": "/test_run/owner"
+          },
+          {
+            "name": "is_dynamic",
+            "type": "boolean",
+            "example": false,
+            "description": "Keep the run's membership live against `filters`. Must be sent INSIDE `test_run` — v1 does not read a top-level `is_dynamic` and will silently create a static run if you put it there.",
+            "json_path": "/test_run/is_dynamic"
+          },
+          {
+            "name": "configurations",
+            "type": "array",
+            "example": [],
+            "description": "Configuration ids to run against — ids, not the configuration objects returned on read.",
+            "json_path": "/test_run/configurations"
+          },
+          {
+            "name": "test_plans",
+            "type": "array",
+            "example": [],
+            "description": "Test plan ids. Only the first entry is linked; a run belongs to at most one plan.",
+            "json_path": "/test_run/test_plans"
+          },
+          {
+            "name": "tags",
+            "type": "array",
+            "example": [
+              "login"
+            ],
+            "json_path": "/test_run/tags"
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "fields": [
+              {
+                "name": "issue_id",
+                "type": "string"
+              },
+              {
+                "name": "issue_type",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_run/issues"
+          },
+          {
+            "name": "environment",
+            "type": "string",
+            "json_path": "/test_run/environment"
+          },
+          {
+            "name": "attachments",
+            "type": "array",
+            "json_path": "/test_run/attachments"
+          },
+          {
+            "name": "metadata",
+            "type": "object",
+            "json_path": "/test_run/metadata"
+          },
+          {
+            "name": "build_group_id",
+            "type": "integer",
+            "json_path": "/test_run/build_group_id"
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "example": false,
+            "json_path": "/selection/select_all"
+          },
+          {
+            "name": "unique_test_case_count",
+            "type": "integer",
+            "example": 83,
+            "json_path": "/selection/unique_test_case_count"
+          },
+          {
+            "name": "folders",
+            "type": "object",
+            "json_path": "/selection/folders"
+          },
+          {
+            "name": "trtc_configuration_mappings",
+            "type": "array",
+            "fields": [
+              {
+                "name": "configuration_id",
+                "type": "integer"
+              },
+              {
+                "name": "select_all",
+                "type": "boolean"
+              },
+              {
+                "name": "linked_test_cases",
+                "type": "array"
+              },
+              {
+                "name": "unlinked_test_cases",
+                "type": "array"
+              }
+            ]
+          }
+        ],
+        "intent": "Create a test run for a project",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "active_state",
+          "assignee_imported",
+          "created_at",
+          "description",
+          "environment",
+          "is_automation",
+          "is_dynamic",
+          "observability_url",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestRunWriteResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/admin-v2/settings/custom-fields/{custom_fields_id}/datasets/{dataset_id}/options/{option_id}/delete",
+        "mode": "destructive",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "dataset_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "option_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "custom_fields_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Delete one option (POST to /delete) — DESTRUCTIVE, drops values using it.",
+        "responses": {
+          "200": {
+            "description": "`{success: true}`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/admin-v2/settings/custom-fields/{custom_fields_id}/datasets/{dataset_id}/delete",
+        "mode": "destructive",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "dataset_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "custom_fields_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Delete a dataset (POST to /delete) — DESTRUCTIVE, drops its options and values.",
+        "responses": {
+          "200": {
+            "description": "`{success: true}`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/admin-v2/settings/custom-fields/{custom_fields_id}/delete",
+        "mode": "destructive",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "custom_fields_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Delete a field definition (POST to /delete) — DESTRUCTIVE, cascades to stored values.",
+        "responses": {
+          "200": {
+            "description": "`{success: true}`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/v1/projects/{project_id}/datasets/{uuid}",
+        "mode": "destructive",
+        "entity": "dataset",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "uuid",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "intent": "Delete a dataset.",
+        "responses": {
+          "200": {
+            "description": "Dataset deleted successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "description": "Indicates if the deletion was successful.",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "description": "Success message.",
+                  "example": "DatasetV2 deleted successfully"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions/{session_id}",
+        "mode": "destructive",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "type": "integer",
+            "required": true,
+            "example": 123
+          }
+        ],
+        "intent": "Delete an exploratory session",
+        "responses": {
+          "200": {
+            "description": "Exploratory session deleted successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                }
+              }
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden. Insufficient permissions to delete this session.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "message": {
+                  "type": "string",
+                  "example": "You don't have permission to delete this exploratory session"
+                }
+              }
+            }
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions/{session_id}/logs/{log_id}",
+        "mode": "destructive",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "type": "integer",
+            "required": true,
+            "example": 123
+          },
+          {
+            "name": "log_id",
+            "type": "integer",
+            "required": true,
+            "example": 789
+          }
+        ],
+        "intent": "Delete a session log entry",
+        "responses": {
+          "200": {
+            "description": "Session log deleted successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                }
+              }
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/v1/projects/{project_id}/filter/{filter_id}",
+        "mode": "destructive",
+        "entity": "filter",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "filter_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Delete a filter",
+        "responses": {
+          "200": {
+            "$response": "FilterDeleteResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/rm",
+        "mode": "destructive",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Delete a folder and its contents",
+        "returns": [
+          "id",
+          "name",
+          "cases_count",
+          "group_id",
+          "is_automation",
+          "project_id",
+          "sub_folders_count",
+          "total_cases_count"
+        ],
+        "responses": {
+          "200": {
+            "description": "Folder and its contents deleted successfully",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "folder": {
+                      "$schema": "Folder"
+                    },
+                    "path_folders": {
+                      "type": "array",
+                      "items": {
+                        "$schema": "Folder"
+                      }
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/v1/projects/{project_id}/reports/schedules/{schedule_id}",
+        "mode": "destructive",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "schedule_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "q[query]",
+            "type": "string"
+          }
+        ],
+        "intent": "Delete a report (this removes the report itself, not just its schedule)",
+        "returns": [
+          "id",
+          "identifier",
+          "title",
+          "created_at",
+          "custom_date_range",
+          "description",
+          "frequency",
+          "group_id",
+          "next_run_at",
+          "project_id",
+          "report_creation_mode",
+          "report_timeframe"
+        ],
+        "responses": {
+          "200": {
+            "$response": "DeleteScheduleResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/v1/projects/{project_id}/shared-steps/{shared_step_id}",
+        "mode": "destructive",
+        "entity": "shared_step",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "shared_step_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Delete a shared step",
+        "responses": {
+          "204": {
+            "description": "Shared step deleted successfully"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases/{test_case_id}/attachments/{attachment_id}/delete",
+        "mode": "destructive",
+        "entity": "attachment",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "attachment_id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "intent": "Delete an attachment from a test case in a folder in a project",
+        "returns": [
+          "id",
+          "byte_size",
+          "content_type",
+          "filename"
+        ],
+        "responses": {
+          "200": {
+            "description": "Attachment deleted successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "attachments": {
+                  "$schema": "AttachmentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-plans/{test_plan_id}/delete",
+        "mode": "destructive",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_plan_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Delete a test plan (or sub-plan) — no bin, no undo",
+        "responses": {
+          "200": {
+            "description": "Plan deleted.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "description": "No such plan: `{success: false, error: \"Test Plan not found\"}`.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "error": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-results/{test_result_id}/delete",
+        "mode": "destructive",
+        "entity": "result",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_result_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Delete one test result",
+        "responses": {
+          "200": {
+            "description": "Result deleted.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/delete",
+        "mode": "destructive",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true,
+            "example": "TR-14"
+          }
+        ],
+        "intent": "delete test run",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "active_state",
+          "assignee_imported",
+          "created_at",
+          "description",
+          "environment",
+          "is_automation",
+          "is_dynamic",
+          "observability_url",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestRunResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "PUT",
+        "path": "/api/v1/projects/{project_id}/ai-duplicates/{duplicate_id}",
+        "mode": "write",
+        "entity": "duplicate",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "duplicate_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "discard_reason",
+            "type": "string",
+            "description": "Short reason code / label for why this isn't a duplicate."
+          },
+          {
+            "name": "user_feedback",
+            "type": "string",
+            "description": "Free-text feedback from the user."
+          }
+        ],
+        "intent": "Discard a duplicate suggestion — dismisses it WITHOUT touching test cases",
+        "responses": {
+          "200": {
+            "description": "Duplicate discarded.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "description": "No such duplicate for this group."
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/reports/{report_id}/download",
+        "mode": "write",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "report_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "file_type",
+            "type": "string",
+            "required": true,
+            "values": [
+              "csv",
+              "pdf",
+              "xlsx"
+            ],
+            "example": "csv",
+            "description": "Desired export format. Note this is a STRING here, while the same-named field\non `send_email_now` is an ARRAY."
+          },
+          {
+            "name": "required",
+            "type": "object",
+            "description": "Optional column selection, honoured only for `Test Run Detailed Report`\n(ignored for every other type). Shape:\n`{ \"<entity>\": { \"fields\": [\"id\",\"title\",...] } }`. Omit to get the report's\ndefault columns."
+          }
+        ],
+        "intent": "Initiate a download of a report in a specified file format",
+        "returns": [
+          "channel"
+        ],
+        "responses": {
+          "200": {
+            "$response": "DownloadReportResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "PATCH",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases/{test_case_id}/edit-v2",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "attachments",
+            "type": "array",
+            "description": "The COMPLETE set of attachment blob ids the case should end up with, not a list to append — any currently-attached id missing from the array is detached. Read the case's existing attachments first and send them back alongside the new ids.",
+            "json_path": "/test_case/attachments"
+          },
+          {
+            "name": "automation_state",
+            "type": "integer",
+            "json_path": "/test_case/automation_state"
+          },
+          {
+            "name": "automation_status",
+            "type": "string",
+            "description": "Legacy alias for `automation_state`, given as an internal_name string (e.g. `not_automated`, `automated`). Applied only when `automation_state` is omitted.",
+            "json_path": "/test_case/automation_status"
+          },
+          {
+            "name": "case_type",
+            "type": "integer",
+            "example": 490,
+            "json_path": "/test_case/case_type"
+          },
+          {
+            "name": "custom_fields",
+            "type": "object",
+            "example": {
+              "123": "option_value",
+              "456": [
+                "multi",
+                "select"
+              ]
+            },
+            "json_path": "/test_case/custom_fields"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "json_path": "/test_case/description"
+          },
+          {
+            "name": "estimate",
+            "type": "string",
+            "description": "ACCEPTED BUT NOT PERSISTED — passes validation and is then dropped before the write, on this path as well as create. Use `estimated_duration_seconds`; never report an estimate as saved.",
+            "json_path": "/test_case/estimate"
+          },
+          {
+            "name": "estimated_duration_seconds",
+            "type": "integer",
+            "description": "Per-case estimated execution time in SECONDS; `null` clears it. This is the field that actually stores an estimate.",
+            "json_path": "/test_case/estimated_duration_seconds"
+          },
+          {
+            "name": "expected_result",
+            "type": "string",
+            "description": "Overall expected outcome, distinct from a step's own `result`.",
+            "json_path": "/test_case/expected_result"
+          },
+          {
+            "name": "is_dataset_modified",
+            "type": "boolean",
+            "description": "Must be `true` for a `test_case_dataset` change to be applied; with any other value the dataset payload is ignored.",
+            "json_path": "/test_case/is_dataset_modified"
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "example": [
+              {
+                "issue_id": "TM-1234",
+                "issue_type": "jira"
+              }
+            ],
+            "description": "Linked issues/defects. Processed ASYNCHRONOUSLY after the response returns, so a 200 does not mean the links exist yet — re-read the case to confirm.",
+            "fields": [
+              {
+                "name": "issue_id",
+                "type": "string"
+              },
+              {
+                "name": "issue_type",
+                "type": "string"
+              },
+              {
+                "name": "metadata",
+                "type": "object"
+              }
+            ],
+            "json_path": "/test_case/issues"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "example": "Verify login functionality",
+            "description": "The name/title of the test case.",
+            "json_path": "/test_case/name"
+          },
+          {
+            "name": "owner",
+            "type": "integer",
+            "json_path": "/test_case/owner"
+          },
+          {
+            "name": "preconditions",
+            "type": "string",
+            "json_path": "/test_case/preconditions"
+          },
+          {
+            "name": "priority",
+            "type": "integer",
+            "example": 483,
+            "json_path": "/test_case/priority"
+          },
+          {
+            "name": "review_status",
+            "type": "string",
+            "description": "Review state, e.g. `pending` / `in_review` / `approved`. Unlike POST .../edit, omitting it here leaves the stored value untouched.",
+            "json_path": "/test_case/review_status"
+          },
+          {
+            "name": "reviewers",
+            "type": "array",
+            "description": "Reviewer TM user ids (emails also resolve). Honoured only on a Team-Pro workspace with review-approve enabled on the project — otherwise silently ignored. Including the owner is rejected with 422 \"Owner cannot be a reviewer\".",
+            "json_path": "/test_case/reviewers"
+          },
+          {
+            "name": "status",
+            "type": "integer",
+            "example": 496,
+            "json_path": "/test_case/status"
+          },
+          {
+            "name": "steps",
+            "type": "string",
+            "description": "LEGACY — use `test_case_steps` instead. This param skips the request allowlist and is read with JSON.parse, so it must be a JSON-encoded STRING. Sending a real JSON array parses to `[]` and WIPES the case's steps while still returning 200.",
+            "json_path": "/test_case/steps"
+          },
+          {
+            "name": "tags",
+            "type": "array",
+            "example": [
+              "regression",
+              "smoke"
+            ],
+            "description": "Tag names. `[]` removes all tags; omit the field to keep the existing ones.",
+            "json_path": "/test_case/tags"
+          },
+          {
+            "name": "template",
+            "type": "string",
+            "description": "Template NAME (the same values the create paths accept) — not an id. Sending an integer is rejected with 422 \"Invalid template value <n>\"; use `template_id` for the numeric custom-template reference.",
+            "json_path": "/test_case/template"
+          },
+          {
+            "name": "template_id",
+            "type": "integer",
+            "description": "Custom-template id.",
+            "json_path": "/test_case/template_id"
+          },
+          {
+            "name": "template_step_type",
+            "type": "string",
+            "description": "Takes precedence over `template` when both are sent.",
+            "json_path": "/test_case/template_step_type"
+          },
+          {
+            "name": "test_case_dataset",
+            "type": "string",
+            "description": "Dataset binding for a data-driven case. On this path it is applied only when `is_dataset_modified` is true.",
+            "fields": [
+              {
+                "name": "variables",
+                "type": "array"
+              },
+              {
+                "name": "rows",
+                "type": "array"
+              }
+            ],
+            "json_path": "/test_case/test_case_dataset"
+          },
+          {
+            "name": "test_case_folder_id",
+            "type": "string",
+            "description": "Move the case to a different folder (integer id). Dropped server-side when it matches the current folder, so passing the existing folder is a safe no-op.",
+            "json_path": "/test_case/test_case_folder_id"
+          },
+          {
+            "name": "test_case_steps",
+            "type": "array",
+            "example": [
+              {
+                "order": 1,
+                "step": "Navigate to the login page",
+                "result": "The login page is displayed"
+              },
+              {
+                "order": 2,
+                "step": "Submit valid credentials",
+                "result": "The user lands on the dashboard"
+              }
+            ],
+            "description": "The structured step list — same shape as the create body. `order` is filled in by position when omitted. `[]` removes all steps; omit the field to keep them.",
+            "fields": [
+              {
+                "name": "order",
+                "type": "integer"
+              },
+              {
+                "name": "step",
+                "type": "string"
+              },
+              {
+                "name": "result",
+                "type": "string"
+              },
+              {
+                "name": "test_data",
+                "type": "string"
+              },
+              {
+                "name": "shared_step_id",
+                "type": "integer"
+              }
+            ],
+            "json_path": "/test_case/test_case_steps"
+          }
+        ],
+        "intent": "Partially edit a test case (v2)",
+        "returns": [
+          "result",
+          "step"
+        ],
+        "responses": {
+          "200": {
+            "description": "Test case successfully updated",
+            "schema": {
+              "$schema": "TestCase"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases/{test_case_id}/edit",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "attachments",
+            "type": "array",
+            "json_path": "/test_case/attachments"
+          },
+          {
+            "name": "automation_state",
+            "type": "integer",
+            "json_path": "/test_case/automation_state"
+          },
+          {
+            "name": "automation_status",
+            "type": "string",
+            "description": "Legacy alias for `automation_state`, taken as an internal_name string (e.g. `not_automated`, `automated`). Only applied when `automation_state` is omitted. Prefer `automation_state`.",
+            "json_path": "/test_case/automation_status"
+          },
+          {
+            "name": "case_type",
+            "type": "integer",
+            "json_path": "/test_case/case_type"
+          },
+          {
+            "name": "custom_fields",
+            "type": "object",
+            "json_path": "/test_case/custom_fields"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "json_path": "/test_case/description"
+          },
+          {
+            "name": "estimate",
+            "type": "string",
+            "description": "ACCEPTED BUT NOT PERSISTED — the field passes request validation and is then dropped before the write on both the create and the edit paths. Use `estimated_duration_seconds` instead; do not report an estimate as saved.",
+            "json_path": "/test_case/estimate"
+          },
+          {
+            "name": "estimated_duration_seconds",
+            "type": "integer",
+            "description": "Per-case estimated execution time in SECONDS. `null` clears it. This is the field that actually persists an estimate.",
+            "json_path": "/test_case/estimated_duration_seconds"
+          },
+          {
+            "name": "expected_result",
+            "type": "string",
+            "description": "Overall expected outcome (distinct from a step's own `result`). Rich-text field — send plain text/HTML, not a JSON document.",
+            "json_path": "/test_case/expected_result"
+          },
+          {
+            "name": "is_dataset_modified",
+            "type": "boolean",
+            "description": "Set with `test_case_dataset` on an edit to signal the dataset changed; on create the mappings are always regenerated and this is ignored.",
+            "json_path": "/test_case/is_dataset_modified"
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "json_path": "/test_case/issues"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "json_path": "/test_case/name"
+          },
+          {
+            "name": "owner",
+            "type": "integer",
+            "json_path": "/test_case/owner"
+          },
+          {
+            "name": "preconditions",
+            "type": "string",
+            "json_path": "/test_case/preconditions"
+          },
+          {
+            "name": "priority",
+            "type": "integer",
+            "json_path": "/test_case/priority"
+          },
+          {
+            "name": "review_status",
+            "type": "string",
+            "description": "Review state, e.g. `pending` / `in_review` / `approved`. When omitted it is set from the project's review-approve setting, falling back to `pending` — it is never left untouched on create or on POST .../edit.",
+            "json_path": "/test_case/review_status"
+          },
+          {
+            "name": "reviewers",
+            "type": "array",
+            "description": "Reviewer TM user ids (emails also resolve). Only honoured when the workspace is on a Team-Pro plan AND the project has review-approve enabled; otherwise silently ignored. Including the `owner` is rejected with 422 \"Owner cannot be a reviewer\".",
+            "json_path": "/test_case/reviewers"
+          },
+          {
+            "name": "send_for_review",
+            "type": "boolean",
+            "description": "EDIT PATHS ONLY — drives the per-reviewer review-request email. Dropped without error on create (the create flow already notifies from `reviewers` + `review_status`) and not accepted by PATCH .../edit-v2.",
+            "json_path": "/test_case/send_for_review"
+          },
+          {
+            "name": "shared_precondition_id",
+            "type": "integer",
+            "description": "Link a shared precondition. Only applied when `preconditions` is sent in the same body.",
+            "json_path": "/test_case/shared_precondition_id"
+          },
+          {
+            "name": "status",
+            "type": "integer",
+            "json_path": "/test_case/status"
+          },
+          {
+            "name": "tags",
+            "type": "array",
+            "json_path": "/test_case/tags"
+          },
+          {
+            "name": "template",
+            "type": "string",
+            "json_path": "/test_case/template"
+          },
+          {
+            "name": "template_id",
+            "type": "integer",
+            "json_path": "/test_case/template_id"
+          },
+          {
+            "name": "template_step_type",
+            "type": "string",
+            "description": "Step shape — `test_case_steps` | `test_case_text` | `test_case_bdd`. OPTIONAL; when sending `template_id`, use that template's own `step_type` from the templates listing rather than assuming.",
+            "json_path": "/test_case/template_step_type"
+          },
+          {
+            "name": "test_case_dataset",
+            "type": "string",
+            "description": "Dataset binding for a data-driven case. On create the mappings are always regenerated from this, so `is_dataset_modified` is ignored here.",
+            "fields": [
+              {
+                "name": "variables",
+                "type": "array"
+              },
+              {
+                "name": "rows",
+                "type": "array"
+              }
+            ],
+            "json_path": "/test_case/test_case_dataset"
+          },
+          {
+            "name": "test_case_folder_id",
+            "type": "string",
+            "description": "Target folder's integer id. On create this is REQUIRED IN THE BODY as well as in the path — omitting it is the most common create failure (422 wrapping an upstream 404). Integer or string are equivalent; the server coerces with .to_i, so the distinction does not matter.",
+            "json_path": "/test_case/test_case_folder_id"
+          },
+          {
+            "name": "test_case_steps",
+            "type": "array",
+            "description": "The ONLY key the server reads for steps — on single create, bulk create and the update paths alike. Items are `{step, result, test_data?, order?, shared_step_id?}`; `order` is filled in by position when omitted. A differently named key such as `steps` is dropped by strong params and the create still returns 200 for a case with NO steps, so verify against `test_case_steps` in the response.",
+            "json_path": "/test_case/test_case_steps"
+          }
+        ],
+        "intent": "Edit a test case",
+        "returns": [
+          "result",
+          "step"
+        ],
+        "responses": {
+          "200": {
+            "description": "Test case successfully duplicated",
+            "schema": {
+              "$schema": "TestCase"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/edit",
+        "mode": "write",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true,
+            "example": "TR-14"
+          }
+        ],
+        "body": [
+          {
+            "name": "filters",
+            "type": "object",
+            "example": {
+              "priority": [
+                "High"
+              ],
+              "folder_ids": [
+                105
+              ]
+            },
+            "description": "Forward-sync rule for a DYNAMIC run, at the TOP level of the body — not inside `test_run`. This does NOT select cases: it never back-fills existing ones, so a create whose only case-bearing key is `filters` returns 200 with an EMPTY run. Use `test_case_ids` or `selection` to put cases in the run, and send `filters` only in addition, when the user asked the run to stay in sync.\nSending a non-empty "
+          },
+          {
+            "name": "dynamic_filter",
+            "type": "object",
+            "example": {
+              "owner": [],
+              "status": [],
+              "priority": []
+            },
+            "description": "Filter criteria (backward compatible format - use `filters` instead). Top level, same as `filters`, including that it selects no cases and flips the run dynamic."
+          },
+          {
+            "name": "test_case_ids",
+            "type": "array",
+            "example": [
+              2336
+            ]
+          },
+          {
+            "name": "auto_assign",
+            "type": "boolean"
+          },
+          {
+            "name": "shared_selection",
+            "type": "object",
+            "description": "Selection of cases shared in from other projects. Top level, same as `selection`."
+          },
+          {
+            "name": "run_state",
+            "type": "string",
+            "required": true,
+            "values": [
+              "new_run",
+              "in_progress",
+              "under_review",
+              "rejected",
+              "done",
+              "closed"
+            ],
+            "example": "new_run",
+            "description": "MANDATORY. The v1 endpoint validates this against the enum and hard-rejects anything else (including a missing key) with `400 \"invalid data\"`. Use `new_run` for a freshly created run. Note: v2 defaulted this to `new_run` server-side; v1 does NOT.",
+            "json_path": "/test_run/run_state"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "example": "Regression – Login",
+            "json_path": "/test_run/name"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "example": "",
+            "json_path": "/test_run/description"
+          },
+          {
+            "name": "owner",
+            "type": "integer",
+            "example": 2,
+            "description": "TM user id of the run owner. Unresolvable ids are silently treated as unassigned rather than erroring.",
+            "json_path": "/test_run/owner"
+          },
+          {
+            "name": "is_dynamic",
+            "type": "boolean",
+            "example": false,
+            "description": "Keep the run's membership live against `filters`. Must be sent INSIDE `test_run` — v1 does not read a top-level `is_dynamic` and will silently create a static run if you put it there.",
+            "json_path": "/test_run/is_dynamic"
+          },
+          {
+            "name": "configurations",
+            "type": "array",
+            "example": [],
+            "description": "Configuration ids to run against — ids, not the configuration objects returned on read.",
+            "json_path": "/test_run/configurations"
+          },
+          {
+            "name": "test_plans",
+            "type": "array",
+            "example": [],
+            "description": "Test plan ids. Only the first entry is linked; a run belongs to at most one plan.",
+            "json_path": "/test_run/test_plans"
+          },
+          {
+            "name": "tags",
+            "type": "array",
+            "example": [
+              "login"
+            ],
+            "json_path": "/test_run/tags"
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "fields": [
+              {
+                "name": "issue_id",
+                "type": "string"
+              },
+              {
+                "name": "issue_type",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_run/issues"
+          },
+          {
+            "name": "environment",
+            "type": "string",
+            "json_path": "/test_run/environment"
+          },
+          {
+            "name": "attachments",
+            "type": "array",
+            "json_path": "/test_run/attachments"
+          },
+          {
+            "name": "metadata",
+            "type": "object",
+            "json_path": "/test_run/metadata"
+          },
+          {
+            "name": "build_group_id",
+            "type": "integer",
+            "json_path": "/test_run/build_group_id"
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "example": false,
+            "json_path": "/selection/select_all"
+          },
+          {
+            "name": "unique_test_case_count",
+            "type": "integer",
+            "example": 83,
+            "json_path": "/selection/unique_test_case_count"
+          },
+          {
+            "name": "folders",
+            "type": "object",
+            "json_path": "/selection/folders"
+          },
+          {
+            "name": "trtc_configuration_mappings",
+            "type": "array",
+            "fields": [
+              {
+                "name": "configuration_id",
+                "type": "integer"
+              },
+              {
+                "name": "select_all",
+                "type": "boolean"
+              },
+              {
+                "name": "linked_test_cases",
+                "type": "array"
+              },
+              {
+                "name": "unlinked_test_cases",
+                "type": "array"
+              }
+            ]
+          }
+        ],
+        "intent": "Edit Test Run",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "active_state",
+          "assignee_imported",
+          "created_at",
+          "description",
+          "environment",
+          "is_automation",
+          "is_dynamic",
+          "observability_url",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestRunWriteResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/dashboard-analytics/download",
+        "mode": "write",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "type",
+            "type": "string",
+            "required": true,
+            "values": [
+              "csv",
+              "pdf",
+              "excel"
+            ],
+            "example": "csv",
+            "description": "Export file format"
+          },
+          {
+            "name": "start_date",
+            "type": "string",
+            "example": "2025-01-01",
+            "json_path": "/filters/start_date"
+          },
+          {
+            "name": "end_date",
+            "type": "string",
+            "example": "2025-12-31",
+            "json_path": "/filters/end_date"
+          },
+          {
+            "name": "status",
+            "type": "array",
+            "example": [
+              "passed",
+              "failed"
+            ],
+            "json_path": "/filters/status"
+          }
+        ],
+        "intent": "Export dashboard analytics data",
+        "returns": [
+          "export_id"
+        ],
+        "responses": {
+          "200": {
+            "$response": "DashboardExportInitiatedResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/dashboard-analytics/active-test-runs-info",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get active test run result statistics",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "$response": "ActiveTestRunsInfo"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-cases/archived_test_cases",
+        "mode": "read",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get archived test cases.",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "description": "Archived test cases retrieved",
+            "schema": {
+              "$schema": "TestCaseListResponse"
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-plans/archive_count",
+        "mode": "read",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Count archived test plans",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "Archived plan count.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "count": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/dashboard-analytics/automation-stats",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get automation stats analytics",
+        "returns": [
+          "automated_coverage",
+          "automated_test_cases",
+          "empty_data",
+          "manual_test_cases",
+          "total_test_cases"
+        ],
+        "responses": {
+          "200": {
+            "$response": "AutomationStats"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-runs/closed",
+        "mode": "read",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get all the closed test runs for a project",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "active_state",
+          "assignee_imported",
+          "created_at",
+          "description",
+          "environment",
+          "is_automation",
+          "is_dynamic",
+          "observability_url",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestRunsListResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/dashboard-analytics/closed-test-runs-info",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get closed test run analytics",
+        "returns": [
+          "month"
+        ],
+        "responses": {
+          "200": {
+            "$response": "ClosedTestRunsInfo"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/dashboard-analytics/closed-test-runs-split",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get closed test runs split analytics",
+        "returns": [
+          "name"
+        ],
+        "responses": {
+          "200": {
+            "$response": "ClosedTestRunsSplit"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/configurations",
+        "mode": "read",
+        "entity": "configuration",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get configurations for a project",
+        "returns": [
+          "id",
+          "name",
+          "created_at",
+          "group_id",
+          "is_suggested",
+          "record_status"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved configurations",
+            "schema": {
+              "$schema": "ConfigurationListResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/admin-v2/settings/custom-fields/{custom_fields_id}/datasets/{dataset_id}",
+        "mode": "read",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "dataset_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "custom_fields_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Read one dataset — its project links and option set.",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "The dataset under `data`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/admin-v2/settings/custom-fields/{custom_fields_id}",
+        "mode": "read",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "custom_fields_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Read one custom field definition, with its datasets and project links.",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "The definition under `data`, with `datasets[]`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/{entity_type}/custom-fields/{field_id}",
+        "mode": "read",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "entity_type",
+            "type": "string",
+            "required": true,
+            "values": [
+              "test-case",
+              "test-result",
+              "test-plan"
+            ]
+          },
+          {
+            "name": "field_id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "q",
+            "type": "string"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "Get the allowed values/options of one custom field.",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Field values (top-level key is the field id).",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/datasets/{uuid}",
+        "mode": "read",
+        "entity": "dataset",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "uuid",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "intent": "Get a specific dataset.",
+        "returns": [
+          "name",
+          "created_at",
+          "rows_count",
+          "uuid"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response containing the dataset details.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "description": "Indicates if the update was successful.",
+                  "example": true
+                },
+                "dataset": {
+                  "$schema": "Dataset"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/datasets/{uuid}/test-cases",
+        "mode": "read",
+        "entity": "dataset",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "uuid",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "Get test cases linked to a dataset",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "A list of test cases linked to the dataset.",
+            "schema": {
+              "type": "object",
+              "required": [
+                "test_cases",
+                "info"
+              ],
+              "properties": {
+                "test_cases": {
+                  "type": "array",
+                  "description": "The test cases linked to the dataset.",
+                  "items": {
+                    "type": "object"
+                  }
+                },
+                "info": {
+                  "$schema": "PageInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "description": "`Feature not available` — the group lacks the Team Pro plan. Not a payload error; do not retry with a different body."
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/datasets/variables",
+        "mode": "read",
+        "entity": "dataset",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "q[name]",
+            "type": "string"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "Get dataset variables/columns.",
+        "returns": [
+          "name",
+          "uuid"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "A successful response containing a list of dataset variables.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "description": "Indicates if the request was successful.",
+                  "example": true
+                },
+                "variables": {
+                  "$schema": "DatasetVariablesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/ai-duplicates/status",
+        "mode": "read",
+        "entity": "duplicate",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Dedupe job status — use this to tell \"feature off\" from \"no duplicates\"",
+        "returns": [
+          "status"
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest dedupe job status, or `{status: \"NOT_ENABLED\"}` when none exists.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`project_id` missing."
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/ai-duplicates/{duplicate_id}/source_tc",
+        "mode": "read",
+        "entity": "duplicate",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "duplicate_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Read the pre-merge snapshot of a MERGED duplicate's source test case",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "The pre-merge source test case snapshot.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "404": {
+            "description": "Duplicate not found, not `merged`, or no snapshot retained."
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/ai-duplicates/{duplicate_id}",
+        "mode": "read",
+        "entity": "duplicate",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "duplicate_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Read one suggested duplicate, with its test cases resolved",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "The duplicate with its resolved test cases.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found, or its status is not `suggested`."
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/{entity}/filter-details",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "entity",
+            "type": "string",
+            "required": true,
+            "values": [
+              "test-cases",
+              "trtc",
+              "test-runs"
+            ],
+            "example": "test-cases"
+          }
+        ],
+        "query": [
+          {
+            "name": "q[query]",
+            "type": "string",
+            "example": "login functionality"
+          },
+          {
+            "name": "q[folder_ids]",
+            "type": "string",
+            "example": "3306878,3669741,5422801,5422802"
+          },
+          {
+            "name": "q[status]",
+            "type": "string",
+            "example": "9319,9321"
+          },
+          {
+            "name": "q[priority]",
+            "type": "string",
+            "example": "550376,9261"
+          },
+          {
+            "name": "q[automation_state]",
+            "type": "string",
+            "example": "18172471,18172473"
+          },
+          {
+            "name": "q[case_type]",
+            "type": "string",
+            "example": "9379,9375"
+          },
+          {
+            "name": "q[owner]",
+            "type": "string",
+            "example": "user123,user456"
+          },
+          {
+            "name": "q[assignee]",
+            "type": "string",
+            "example": "user789,user101"
+          },
+          {
+            "name": "q[tags]",
+            "type": "string",
+            "example": "regression,smoke"
+          },
+          {
+            "name": "q[created_at]",
+            "type": "string",
+            "example": "2024-01-01..2024-12-31"
+          },
+          {
+            "name": "q[updated_at]",
+            "type": "string",
+            "example": "2024-01-01..2024-12-31"
+          }
+        ],
+        "intent": "Get filter details for entity",
+        "returns": [
+          "id",
+          "colour",
+          "entity_type",
+          "field_name",
+          "field_value",
+          "internal_name"
+        ],
+        "responses": {
+          "200": {
+            "description": "Filter details retrieved successfully",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "priority": {
+                  "type": "array",
+                  "description": "Available priority options with metadata",
+                  "items": {
+                    "$schema": "ResultStatus"
+                  }
+                },
+                "automation_state": {
+                  "type": "array",
+                  "description": "Available automation state options",
+                  "items": {
+                    "$schema": "ResultStatus"
+                  }
+                },
+                "automation_status": {
+                  "type": "array",
+                  "description": "Available automation status options",
+                  "nullable": true,
+                  "items": {
+                    "$schema": "ResultStatus"
+                  }
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Creation date filter information",
+                  "nullable": true
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Update date filter information",
+                  "nullable": true
+                },
+                "status": {
+                  "type": "array",
+                  "description": "Available status options",
+                  "items": {
+                    "$schema": "ResultStatus"
+                  }
+                },
+                "case_type": {
+                  "type": "array",
+                  "description": "Available status options",
+                  "items": {
+                    "$schema": "ResultStatus"
+                  }
+                },
+                "custom_fields": {
+                  "type": "object",
+                  "description": "Available custom fields for filtering"
+                },
+                "folders": {
+                  "type": "object",
+                  "description": "Comprehensive folder structure and hierarchy",
+                  "properties": {
+                    "folder_tree": {
+                      "type": "array",
+                      "description": "Complete folder tree structure",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "project_id": {
+                            "type": "integer"
+                          },
+                          "group_id": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "is_automation": {
+                            "type": "boolean"
+                          },
+                          "sub_folders_count": {
+                            "type": "integer"
+                          },
+                          "links": {
+                            "type": "object",
+                            "properties": {
+                              "self": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "cases_count": {
+                            "type": "integer"
+                          },
+                          "total_cases_count": {
+                            "type": "integer"
+                          },
+                          "folder_path": {
+                            "type": "string",
+                            "description": "Full path to the folder",
+                            "example": "/3306878/3669741/"
+                          },
+                          "selected_all": {
+                            "type": "boolean",
+                            "description": "Whether all items in folder are selected",
+                            "example": true
+                          },
+                          "ancestors": {
+                            "type": "array",
+                            "description": "Array of ancestor folder IDs",
+                            "example": [
+                              3306878
+                            ],
+                            "items": {
+                              "type": "integer"
+                            }
+                          },
+                          "contents": {
+                            "type": "array",
+                            "description": "Nested folder contents (recursive)",
+                            "items": {
+                              "$schema": "Folder"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "folders": {
+                      "type": "array",
+                      "description": "Flattened list of all folders",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "project_id": {
+                            "type": "integer"
+                          },
+                          "group_id": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "is_automation": {
+                            "type": "boolean"
+                          },
+                          "sub_folders_count": {
+                            "type": "integer"
+                          },
+                          "links": {
+                            "type": "object",
+                            "properties": {
+                              "self": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "cases_count": {
+                            "type": "integer"
+                          },
+                          "total_cases_count": {
+                            "type": "integer"
+                          },
+                          "folder_path": {
+                            "type": "string",
+                            "example": "/3306878/3669741/"
+                          },
+                          "selected_all": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "ancestors": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions/{session_id}",
+        "mode": "read",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "type": "integer",
+            "required": true,
+            "example": 123
+          }
+        ],
+        "intent": "Get an exploratory session",
+        "returns": [
+          "id",
+          "title",
+          "actual_duration",
+          "charter",
+          "created_at",
+          "description",
+          "duration",
+          "folder_id",
+          "session_log_count",
+          "session_state",
+          "timebox_duration",
+          "updated_at"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the exploratory session.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "exploratory_session": {
+                  "$schema": "ExploratorySession"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/reports/exploratory-session-summary",
+        "mode": "read",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "mode",
+            "type": "string",
+            "values": [
+              "time_period",
+              "session_selection"
+            ]
+          },
+          {
+            "name": "start_date",
+            "type": "string"
+          },
+          {
+            "name": "end_date",
+            "type": "string"
+          },
+          {
+            "name": "session_ids",
+            "type": "string"
+          }
+        ],
+        "intent": "Exploratory Session Summary — live view, no saved report needed",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/filter/{filter_id}",
+        "mode": "read",
+        "entity": "filter",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "filter_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get filter details",
+        "returns": [
+          "id",
+          "name",
+          "created_at",
+          "entity_type",
+          "is_project_level",
+          "owner",
+          "project_id",
+          "updated_at"
+        ],
+        "responses": {
+          "200": {
+            "$response": "FilterDetailResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/rm-summary",
+        "mode": "read",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get summary of entities to be deleted when removing a folder",
+        "returns": [
+          "active_test_case_count",
+          "archived_test_case_count",
+          "sub_folders",
+          "test_recordings_count"
+        ],
+        "responses": {
+          "200": {
+            "$response": "RemoveFolderSummaryResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/repository/mapping",
+        "mode": "read",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get the project's folder tree (v1).",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "Folder tree.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "structure": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/group/users-v2",
+        "mode": "read",
+        "entity": "user",
+        "query": [
+          {
+            "name": "q",
+            "type": "string"
+          }
+        ],
+        "intent": "Get group users V2 with pagination",
+        "returns": [
+          "id",
+          "browserstack_user_id",
+          "email",
+          "full_name",
+          "group_id",
+          "onboarded",
+          "reports_and_notification_enabled"
+        ],
+        "responses": {
+          "200": {
+            "$response": "UsersV2Response"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/dashboard-analytics/issues-count-info",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get issues count analytics",
+        "returns": [
+          "label"
+        ],
+        "responses": {
+          "200": {
+            "$response": "IssuesCountInfo"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get a project by INTEGER id (v1) — full detail + its PR-NNN identifier",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "created_at",
+          "description",
+          "jira_mapped",
+          "starred",
+          "test_cases_count",
+          "test_plans_count",
+          "test_runs_count",
+          "thProjectId",
+          "user_role"
+        ],
+        "responses": {
+          "200": {
+            "description": "Project detail; data.project.identifier is the PR-NNN form.",
+            "schema": {
+              "$schema": "V1ProjectDetail"
+            }
+          },
+          "401": {
+            "description": "Unauthorized — authentication missing or invalid."
+          },
+          "404": {
+            "description": "No project with that integer id (or not visible to this user)."
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/form-fields-v2",
+        "mode": "read",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get project-specific custom fields V2 for test cases",
+        "returns": [
+          "id",
+          "default_value",
+          "entity_type",
+          "field_name",
+          "field_type",
+          "group_id",
+          "is_bulk_editable",
+          "is_filterable",
+          "is_required",
+          "linked_projects_count",
+          "place_holder_text",
+          "system_name"
+        ],
+        "responses": {
+          "200": {
+            "$response": "CustomFieldsV2Response"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/settings",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "in_review_count",
+            "type": "string",
+            "values": [
+              "true"
+            ]
+          }
+        ],
+        "intent": "Get project settings",
+        "returns": [
+          "in_review_count",
+          "test_plan_in_review_count"
+        ],
+        "responses": {
+          "200": {
+            "description": "Project settings successfully retrieved",
+            "schema": {
+              "type": "object",
+              "required": [
+                "success",
+                "project_settings"
+              ],
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "project_settings": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                },
+                "info": {
+                  "type": "object",
+                  "description": "Pagination/meta info passthrough from the upstream service"
+                },
+                "meta_data": {
+                  "type": "object",
+                  "description": "Per-user review counts (present when in_review_count=true)",
+                  "properties": {
+                    "in_review_count": {
+                      "type": "integer",
+                      "description": "Test cases assigned to the current user that are in review",
+                      "example": 4
+                    },
+                    "test_plan_in_review_count": {
+                      "type": "integer",
+                      "description": "Test plans assigned to the current user that are in review",
+                      "example": 2
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/users-v2",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "q",
+            "type": "string"
+          }
+        ],
+        "intent": "Get project users V2 with pagination",
+        "returns": [
+          "id",
+          "browserstack_user_id",
+          "email",
+          "full_name",
+          "group_id",
+          "onboarded",
+          "reports_and_notification_enabled"
+        ],
+        "responses": {
+          "200": {
+            "$response": "UsersV2Response"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/basic",
+        "mode": "read",
+        "entity": "project",
+        "query": [
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          },
+          {
+            "name": "q[query]",
+            "type": "string",
+            "example": "jdoe42"
+          },
+          {
+            "name": "q[identifier]",
+            "type": "string",
+            "example": "PR-60863"
+          }
+        ],
+        "intent": "Get paginated projects (lean payload) — use this to list or count projects",
+        "returns": [
+          "id",
+          "name",
+          "description",
+          "import_id",
+          "normalisedName",
+          "starred",
+          "thProjectId"
+        ],
+        "max_page_size": 300,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "ProjectsPaginatedResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/minify",
+        "mode": "read",
+        "entity": "project",
+        "query": [
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          }
+        ],
+        "intent": "Get all projects (minified dropdown) — has NO name search",
+        "returns": [
+          "id",
+          "name",
+          "description",
+          "import_id",
+          "normalisedName",
+          "starred",
+          "thProjectId"
+        ],
+        "max_page_size": 300,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "ProjectMinifyResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/reports/attachments/{attachment_id}",
+        "mode": "read",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "attachment_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get download URL for a report attachment",
+        "returns": [
+          "url"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved report attachment URL",
+            "schema": {
+              "type": "object",
+              "required": [
+                "url",
+                "success"
+              ],
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "format": "uri",
+                  "example": "https://example.com/download/report.pdf"
+                },
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/reports/{report_id}",
+        "mode": "read",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "report_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "sections",
+            "type": "string",
+            "example": "test_case_created_priority,test_case_top_creators"
+          },
+          {
+            "name": "report_data_only",
+            "type": "boolean"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "today",
+            "type": "string",
+            "example": "2025-05-13"
+          }
+        ],
+        "intent": "Retrieve a scheduled report's config and data — the general report read",
+        "returns": [
+          "id",
+          "identifier",
+          "title",
+          "created_at",
+          "custom_date_range",
+          "description",
+          "frequency",
+          "group_id",
+          "next_run_at",
+          "project_id",
+          "report_creation_mode",
+          "report_timeframe"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "GetReportDetailResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/reports/{report_id}/{section_name}",
+        "mode": "read",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "report_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "section_name",
+            "type": "string",
+            "required": true,
+            "example": "test_case_created_priority"
+          }
+        ],
+        "query": [
+          {
+            "name": "widget_type",
+            "type": "string"
+          },
+          {
+            "name": "segment",
+            "type": "string"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "Fetch one report widget/section — works for EVERY report type.",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Invalid sections passed, or a missing/invalid widget_type on a drilldown section."
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/reports/{report_id}/detail/{report_type}",
+        "mode": "read",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "report_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "report_type",
+            "type": "string",
+            "required": true,
+            "values": [
+              "test_runs_summary",
+              "test_runs_details",
+              "requirement_traceability_report"
+            ]
+          }
+        ],
+        "query": [
+          {
+            "name": "reportTimeRange",
+            "type": "string",
+            "required": true,
+            "values": [
+              "last_one_day",
+              "last_one_week",
+              "last_one_month",
+              "last_three_months",
+              "custom",
+              "specific_test_runs",
+              "specific_test_plans",
+              "specific_test_cases",
+              "specific_sessions",
+              "requirements"
+            ],
+            "example": "last_one_week",
+            "description": "The window a report covers. Also the value of the `reportTimeRange` query param\non the report-detail read.\n\nThe four relative windows compute a date range from \"now\". `custom` computes it\nfrom `custom_date_range` and **requires** that field — sending `custom` without it\nis an unhandled server error, not a 422.\n\nThe five remaining values carry no dates; they select entities through\n`report_filters`"
+          },
+          {
+            "name": "sections",
+            "type": "string",
+            "example": "test_run_data,test_run_status"
+          },
+          {
+            "name": "widget_type",
+            "type": "string",
+            "values": [
+              "active_runs",
+              "closed_runs",
+              "tr_performance",
+              "total_test_cases",
+              "linked_issues",
+              "requirements_linked",
+              "runs_by_state",
+              "defects_linked",
+              "assignee_breakdown",
+              "tcs_by_status"
+            ]
+          },
+          {
+            "name": "segment",
+            "type": "string"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "Get summary statistics for a scheduled report — run and traceability types ONLY",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "ReportSummaryResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/folders",
+        "mode": "read",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "folder_name",
+            "type": "string",
+            "example": "Folder_123",
+            "description": "Name of the folder to search for"
+          },
+          {
+            "name": "include_folder_hierarchy",
+            "type": "boolean",
+            "description": "Whether to include folder hierarchy in the response"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "per_page",
+            "type": "integer"
+          }
+        ],
+        "intent": "Get all folders and subfolders present in the projects.",
+        "returns": [
+          "id",
+          "name",
+          "cases_count",
+          "group_id",
+          "is_automation",
+          "project_id",
+          "sub_folders_count",
+          "total_cases_count"
+        ],
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "RootFolderDetailsResponse"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/reports/{report_id}/selection/edit",
+        "mode": "read",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "report_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get already selected testcases for a tracebility report",
+        "returns": [
+          "select_all",
+          "unique_test_case_count"
+        ],
+        "responses": {
+          "200": {
+            "$response": "GetReportTestCases"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/shared-steps/{shared_step_id}",
+        "mode": "read",
+        "entity": "shared_step",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "shared_step_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "paginated",
+            "type": "boolean"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "Get shared steps",
+        "returns": [
+          "id",
+          "title"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "SharedStepsIDResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/shared-steps",
+        "mode": "read",
+        "entity": "shared_step",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "q[query]",
+            "type": "string"
+          },
+          {
+            "name": "pre_fetch",
+            "type": "boolean"
+          }
+        ],
+        "intent": "Get all shared steps for a project",
+        "returns": [
+          "id",
+          "title",
+          "step_count",
+          "test_case_count"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "SharedStepsGetResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-case/{field_name}",
+        "mode": "read",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "field_name",
+            "type": "string",
+            "required": true,
+            "values": [
+              "priority",
+              "status",
+              "case_type",
+              "automation_state",
+              "defects"
+            ]
+          }
+        ],
+        "query": [
+          {
+            "name": "q",
+            "type": "string"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "THE source for a system field's option ids (priority/status/case_type/automation_state).",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Field values (top-level key is the field name).",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases/{test_case_id}/attachments",
+        "mode": "read",
+        "entity": "attachment",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get all attachments for a test case in a folder in a project",
+        "returns": [
+          "id",
+          "byte_size",
+          "content_type",
+          "filename"
+        ],
+        "responses": {
+          "200": {
+            "description": "Attachments retrieved successfully",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "attachments": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "AttachmentResponse"
+                  }
+                },
+                "success": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases/{test_case_id}",
+        "mode": "read",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get a test case by INTEGER id (v1, folder-scoped) — full detail + its TC-NNN identifier",
+        "returns": [
+          "id",
+          "identifier",
+          "title"
+        ],
+        "responses": {
+          "200": {
+            "description": "Test case detail; data.test_case.identifier is the TC-NNN form.",
+            "schema": {
+              "$schema": "V1TestCaseDetail"
+            }
+          },
+          "401": {
+            "description": "Unauthorized — authentication missing or invalid."
+          },
+          "404": {
+            "description": "No test case with that integer id in that folder (or not visible)."
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/dashboard-analytics/test-case-count-trend",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get test case count trend analytics",
+        "returns": [
+          "field"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestCaseCountTrend"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases/{test_case_id}/detail",
+        "mode": "read",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "include",
+            "type": "string",
+            "example": "folder_path"
+          }
+        ],
+        "intent": "Get Test Case Details",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "description": "Test case details",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "data": {
+                  "$schema": "TestCase"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-cases/{test_case_id}/histories",
+        "mode": "read",
+        "entity": "version",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get test case histories",
+        "returns": [
+          "id",
+          "comment",
+          "created_at",
+          "entity_id",
+          "entity_type",
+          "group_id",
+          "project_id",
+          "source",
+          "user_id",
+          "version_id",
+          "version_name"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved test case histories",
+            "schema": {
+              "$schema": "HistoryListResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-cases/{test_case_id}/histories/diff",
+        "mode": "read",
+        "entity": "version",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "versions[]",
+            "type": "array",
+            "required": true
+          }
+        ],
+        "intent": "Get test case history diff",
+        "returns": [
+          "id",
+          "order",
+          "result",
+          "shared_step_id",
+          "step"
+        ],
+        "responses": {
+          "200": {
+            "$response": "HistoryDiffResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-cases/{test_case_id}/histories/{history_id}",
+        "mode": "read",
+        "entity": "version",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "history_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get a specific test case history",
+        "returns": [
+          "id",
+          "comment",
+          "created_at",
+          "entity_id",
+          "entity_type",
+          "group_id",
+          "project_id",
+          "source",
+          "user_id",
+          "version_id",
+          "version_name"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved test case history",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "history": {
+                  "$schema": "History"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases/{test_case_id}/tags",
+        "mode": "read",
+        "entity": "tag",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get tags and metadata for a test case",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "description": "Tags and test case metadata fetched successfully",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "test_case": {
+                      "$schema": "TestCase"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/dashboard-analytics/test-case-type-split",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get test case type split analytics",
+        "returns": [
+          "name",
+          "field",
+          "value",
+          "y"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestCaseTypeSplit"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/test-cases",
+        "mode": "read",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true,
+            "example": "TR-14"
+          }
+        ],
+        "query": [
+          {
+            "name": "required[fields]",
+            "type": "string",
+            "values": [
+              "count"
+            ]
+          }
+        ],
+        "intent": "Get paginated test cases for a test run",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved test cases.\nResponse format depends on the `required[fields]` parameter:\n- Default: Returns paginated test cases with full data\n- `required[fields]=count`: Returns only the count of matching records\n",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-cases",
+        "mode": "read",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "per_page",
+            "type": "integer"
+          },
+          {
+            "name": "required[fields]",
+            "type": "string",
+            "example": "owner,priority"
+          },
+          {
+            "name": "required[custom_fields]",
+            "type": "string",
+            "example": "121,119"
+          },
+          {
+            "name": "all_folders",
+            "type": "string",
+            "values": [
+              "true"
+            ],
+            "example": "true"
+          }
+        ],
+        "intent": "List a project's test cases — REQUIRES all_folders=true to be project-wide.",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved test cases",
+            "schema": {
+              "$schema": "TestCaseConsolidatedListResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-plans/{test_plan_id}",
+        "mode": "read",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_plan_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get a test plan by INTEGER id (v1) — full detail + its TP-NNN identifier",
+        "returns": [
+          "identifier",
+          "name"
+        ],
+        "responses": {
+          "200": {
+            "description": "Test plan detail; test_plan.identifier (no data wrapper) is the TP-NNN form.",
+            "schema": {
+              "$schema": "V1TestPlanDetail"
+            }
+          },
+          "401": {
+            "description": "Unauthorized — authentication missing or invalid."
+          },
+          "404": {
+            "description": "No test plan with that integer id (or not visible to this user)."
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-plans/execution-trend",
+        "mode": "read",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "test_plan_id",
+            "type": "integer"
+          },
+          {
+            "name": "test_run_id",
+            "type": "integer"
+          },
+          {
+            "name": "today",
+            "type": "string"
+          }
+        ],
+        "intent": "Execution-trend chart data for ONE plan or ONE run (XOR)",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "`{success, data}` — the trend series.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "data": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Neither or both of test_plan_id / test_run_id supplied.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-plans/{test_plan_id}/linked-sessions-chart-data",
+        "mode": "read",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_plan_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Chart data for the exploratory sessions linked to a test plan",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "Linked-session chart data.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-plans/{test_plan_id}/test-runs",
+        "mode": "read",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_plan_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "include_sub_test_plan_runs",
+            "type": "boolean"
+          },
+          {
+            "name": "compact",
+            "type": "boolean"
+          },
+          {
+            "name": "is_archived",
+            "type": "boolean"
+          }
+        ],
+        "intent": "List the test runs linked to a test plan",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Paginated linked test runs.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-results/custom-fields",
+        "mode": "read",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "per_page",
+            "type": "integer"
+          }
+        ],
+        "intent": "Get paginated custom fields for test results",
+        "returns": [
+          "id",
+          "default_value",
+          "entity_type",
+          "field_name",
+          "field_type",
+          "field_user_name",
+          "is_bulk_editable",
+          "is_filterable",
+          "is_required",
+          "optional",
+          "placeholder"
+        ],
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "TestResultCustomFieldsResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/test-cases/{test_case_id}/test-results",
+        "mode": "read",
+        "entity": "result",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true,
+            "example": "TR-14"
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get test results for a test case in a test run",
+        "returns": [
+          "id",
+          "status",
+          "backtrace",
+          "configuration_id",
+          "created_at",
+          "created_by_imported",
+          "custom_fields",
+          "description",
+          "error_description",
+          "expanded",
+          "failure_type",
+          "finished_at"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestResultListResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}",
+        "mode": "read",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Get a test run by INTEGER id (v1) — full detail + its TR-NNN identifier",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "uuid"
+        ],
+        "responses": {
+          "200": {
+            "description": "Test run detail; data.test_run.identifier is the TR-NNN form.",
+            "schema": {
+              "$schema": "V1TestRunDetail"
+            }
+          },
+          "401": {
+            "description": "Unauthorized — authentication missing or invalid."
+          },
+          "404": {
+            "description": "No test run with that integer id (or not visible to this user)."
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/detail",
+        "mode": "read",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "intent": "Get a run with its per-case rows (v1).",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "Run + cases.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-runs/form-fields",
+        "mode": "read",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "all",
+            "type": "boolean"
+          }
+        ],
+        "intent": "Get custom field values for test results in test runs",
+        "returns": [
+          "id",
+          "applies_to_all_projects",
+          "default_value",
+          "entity_type",
+          "field_name",
+          "field_type",
+          "is_required",
+          "link_to_future_projects",
+          "place_holder_text"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestRunFormFieldsResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-runs/selection",
+        "mode": "read",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "example": false,
+            "description": "Select every case in the project.",
+            "json_path": "/selection/select_all"
+          },
+          {
+            "name": "unique_test_case_count",
+            "type": "integer",
+            "example": 2,
+            "json_path": "/selection/unique_test_case_count"
+          },
+          {
+            "name": "folders",
+            "type": "object",
+            "description": "Map of folder id (as a string key) to that folder's selection.",
+            "json_path": "/selection/folders"
+          },
+          {
+            "name": "shared_selection",
+            "type": "object"
+          }
+        ],
+        "intent": "get selected test runs of a project",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestRunsSelectionResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-runs",
+        "mode": "read",
+        "entity": "test_run",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "ignore_run_type",
+            "type": "boolean"
+          },
+          {
+            "name": "include_test_plan",
+            "type": "boolean"
+          }
+        ],
+        "intent": "Get all the test runs for a project",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "active_state",
+          "assignee_imported",
+          "created_at",
+          "description",
+          "environment",
+          "is_automation",
+          "is_dynamic",
+          "observability_url",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "$response": "TestRunsListResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/datasets/import_csv",
+        "mode": "write",
+        "entity": "dataset",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Import a CSV dataset — NOT SUPPORTED in this profile",
+        "responses": {
+          "200": {
+            "description": "CSV file successfully imported",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "headers": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "rows": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/activities",
+        "mode": "read",
+        "entity": "activity",
+        "query": [
+          {
+            "name": "project_id",
+            "type": "integer"
+          },
+          {
+            "name": "cursor",
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "type": "integer"
+          },
+          {
+            "name": "actor_id",
+            "type": "integer"
+          },
+          {
+            "name": "starred_only",
+            "type": "boolean"
+          },
+          {
+            "name": "entity_type",
+            "type": "array"
+          }
+        ],
+        "intent": "Read the activity feed (audit trail) — CURSOR paged, 15-day window",
+        "returns": [
+          "no_starred_projects"
+        ],
+        "responses": {
+          "200": {
+            "description": "A cursor page of activity events.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "events": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                },
+                "pagination": {
+                  "type": "object",
+                  "properties": {
+                    "next_cursor": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "has_next_page": {
+                      "type": "boolean"
+                    },
+                    "limit": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "projects": {
+                  "type": "object",
+                  "description": "Project id → metadata, for resolving event project references."
+                },
+                "no_starred_projects": {
+                  "type": "boolean",
+                  "description": "Present and true only when starred_only was set and the user has none starred."
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-plans/archived_test_plans",
+        "mode": "read",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "List archived test plans",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Paginated archived plans.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/admin-v2/settings/custom-fields/{custom_fields_id}/datasets/{dataset_id}/options",
+        "mode": "read",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "dataset_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "custom_fields_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "List a dataset's options with their ids.",
+        "shape": "discovered",
+        "responses": {
+          "200": {
+            "description": "Options under `data[]`, each with `id`, `option_value`, `is_default`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/datasets",
+        "mode": "read",
+        "entity": "dataset",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "q[name]",
+            "type": "string"
+          },
+          {
+            "name": "q[uuid]",
+            "type": "string"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "List datasets for a project.",
+        "returns": [
+          "name",
+          "created_at",
+          "rows_count",
+          "test_cases_count",
+          "updated_at",
+          "uuid"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "A successful response containing a list of datasets.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "description": "Indicates if the request was successful.",
+                  "example": true
+                },
+                "datasets": {
+                  "$schema": "DatasetsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/ai-duplicates",
+        "mode": "read",
+        "entity": "duplicate",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "page",
+            "type": "integer"
+          },
+          {
+            "name": "entity_type",
+            "type": "string"
+          },
+          {
+            "name": "entity_id",
+            "type": "integer"
+          },
+          {
+            "name": "duplicates",
+            "type": "string"
+          }
+        ],
+        "intent": "List AI-suggested duplicate test cases — an empty list may mean the feature is OFF",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Suggested duplicates. Also the shape returned when the feature flag is off —\nsee the description.\n",
+            "schema": {
+              "$schema": "V1DuplicatesListResponse"
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions/{session_id}/defects",
+        "mode": "read",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "type": "integer",
+            "required": true,
+            "example": 123
+          }
+        ],
+        "query": [
+          {
+            "name": "page",
+            "type": "integer",
+            "example": 1
+          },
+          {
+            "name": "per_page",
+            "type": "integer",
+            "example": 30
+          }
+        ],
+        "intent": "List defects for an exploratory session",
+        "returns": [
+          "issue_id",
+          "issue_type"
+        ],
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved defects for the session.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "defects": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "ExploratorySessionIssue"
+                  }
+                },
+                "info": {
+                  "type": "object",
+                  "properties": {
+                    "page": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "per_page": {
+                      "type": "integer",
+                      "example": 30
+                    },
+                    "total_count": {
+                      "type": "integer",
+                      "example": 5
+                    },
+                    "total_pages": {
+                      "type": "integer",
+                      "example": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions/{session_id}/logs",
+        "mode": "read",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "type": "integer",
+            "required": true,
+            "example": 123
+          }
+        ],
+        "query": [
+          {
+            "name": "page",
+            "type": "integer",
+            "example": 1
+          },
+          {
+            "name": "per_page",
+            "type": "integer",
+            "example": 50
+          }
+        ],
+        "intent": "List logs for an exploratory session",
+        "returns": [
+          "id",
+          "status",
+          "content",
+          "created_at",
+          "elapsed_time",
+          "session_id",
+          "updated_at"
+        ],
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved session logs.",
+            "schema": {
+              "$schema": "ExploratorySessionLogListResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions",
+        "mode": "read",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "page",
+            "type": "integer",
+            "example": 1
+          },
+          {
+            "name": "per_page",
+            "type": "integer",
+            "example": 30
+          },
+          {
+            "name": "q[session_state]",
+            "type": "string",
+            "values": [
+              "active",
+              "closed"
+            ],
+            "example": "active"
+          },
+          {
+            "name": "q[assignee]",
+            "type": "integer",
+            "example": 42
+          },
+          {
+            "name": "q[owner]",
+            "type": "integer",
+            "example": 42
+          },
+          {
+            "name": "q[created_by]",
+            "type": "integer",
+            "example": 10
+          },
+          {
+            "name": "q[created_at_from]",
+            "type": "string",
+            "example": "2026-01-01"
+          },
+          {
+            "name": "q[created_at_to]",
+            "type": "string",
+            "example": "2026-01-31"
+          },
+          {
+            "name": "q[tags][]",
+            "type": "array",
+            "example": [
+              "regression",
+              "payment"
+            ]
+          },
+          {
+            "name": "q[configuration_ids][]",
+            "type": "array",
+            "example": [
+              1,
+              2
+            ]
+          },
+          {
+            "name": "q[search]",
+            "type": "string",
+            "example": "checkout"
+          },
+          {
+            "name": "q[status]",
+            "type": "string",
+            "example": "pass"
+          }
+        ],
+        "intent": "List exploratory sessions for a project",
+        "returns": [
+          "id",
+          "title",
+          "actual_duration",
+          "charter",
+          "created_at",
+          "description",
+          "duration",
+          "folder_id",
+          "session_log_count",
+          "session_state",
+          "timebox_duration",
+          "updated_at"
+        ],
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved exploratory sessions.",
+            "schema": {
+              "$schema": "ExploratorySessionListResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/filter",
+        "mode": "read",
+        "entity": "filter",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "entity",
+            "type": "string",
+            "required": true,
+            "values": [
+              "testcase",
+              "testplan",
+              "testrun",
+              "exploratory_session",
+              "test_plan_test_case"
+            ]
+          },
+          {
+            "name": "page",
+            "type": "integer"
+          }
+        ],
+        "intent": "List filters",
+        "returns": [
+          "id",
+          "name",
+          "created_at",
+          "entity_type",
+          "is_project_level",
+          "owner",
+          "project_id",
+          "updated_at"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "FilterListResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}",
+        "mode": "read",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "List subfolders and folder metadata for a specific folder in a project",
+        "returns": [
+          "id",
+          "name",
+          "cases_count",
+          "group_id",
+          "is_automation",
+          "project_id",
+          "sub_folders_count",
+          "total_cases_count"
+        ],
+        "responses": {
+          "200": {
+            "$response": "FolderDetailsResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases",
+        "mode": "read",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "per_page",
+            "type": "integer"
+          },
+          {
+            "name": "required[fields]",
+            "type": "string",
+            "example": "owner,priority"
+          },
+          {
+            "name": "required[custom_fields]",
+            "type": "string",
+            "example": "121,119"
+          }
+        ],
+        "intent": "List the test cases in one folder",
+        "shape": "discovered",
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Paginated test cases in the folder, with an `info` envelope.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects",
+        "mode": "read",
+        "entity": "project",
+        "query": [
+          {
+            "name": "q",
+            "type": "string",
+            "example": "jdoe42"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "sort_by",
+            "type": "string"
+          },
+          {
+            "name": "starred",
+            "type": "boolean"
+          },
+          {
+            "name": "shared",
+            "type": "boolean"
+          },
+          {
+            "name": "is_hidden_projects",
+            "type": "boolean",
+            "example": true
+          }
+        ],
+        "intent": "List projects for a group.",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "created_at",
+          "description",
+          "import_id",
+          "project_creator",
+          "test_cases_count",
+          "test_runs_count"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "A successful response containing a list of projects.",
+            "schema": {
+              "$schema": "ProjectsListResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/reports/schedules",
+        "mode": "read",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "q[query]",
+            "type": "string"
+          },
+          {
+            "name": "q[scheduled]",
+            "type": "string",
+            "values": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "List all the scheduled reports",
+        "returns": [
+          "id",
+          "identifier",
+          "title",
+          "created_at",
+          "custom_date_range",
+          "description",
+          "frequency",
+          "group_id",
+          "next_run_at",
+          "project_id",
+          "report_creation_mode",
+          "report_timeframe"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "A successful response containing a list of schedules.",
+            "schema": {
+              "$schema": "ReportScheduleGetResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-case/tags-v2",
+        "mode": "read",
+        "entity": "tag",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "q",
+            "type": "string"
+          }
+        ],
+        "intent": "List test-case tags (paginated).",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Tags.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/admin-v2/settings/templates",
+        "mode": "read",
+        "entity": "",
+        "query": [
+          {
+            "name": "entity_type",
+            "type": "string",
+            "values": [
+              "TestCase",
+              "TestResult",
+              "TestPlan",
+              "ExploratorySession"
+            ]
+          },
+          {
+            "name": "project",
+            "type": "integer"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "List the workspace's test-case templates — THE source for `template_id`.",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "`{success, templates: [{id, name, is_system, is_default, step_type}]}`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-plans",
+        "mode": "read",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "include_sub_plans",
+            "type": "boolean"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "values": [
+              "new",
+              "started",
+              "completed"
+            ]
+          },
+          {
+            "name": "sort_by",
+            "type": "string"
+          },
+          {
+            "name": "minify",
+            "type": "boolean"
+          }
+        ],
+        "intent": "List test plans in a project (optionally including sub-plans)",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Paginated test plans with an `info` envelope to page against.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/admin-v2/settings/fields",
+        "mode": "read",
+        "entity": "custom_field",
+        "query": [
+          {
+            "name": "entity_type",
+            "type": "string",
+            "values": [
+              "TestCase",
+              "TestResult",
+              "TestPlan",
+              "ExploratorySession"
+            ]
+          },
+          {
+            "name": "field_source",
+            "type": "string",
+            "values": [
+              "system",
+              "custom",
+              "all"
+            ]
+          },
+          {
+            "name": "field_type",
+            "type": "string"
+          },
+          {
+            "name": "q",
+            "type": "string"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "THE canonical workspace field list (system + custom) — start here for definitions.",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "The workspace's fields under `data[]`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/tags/merge",
+        "mode": "write",
+        "entity": "tag",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "source_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "target_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "entity_type",
+            "type": "string",
+            "required": true,
+            "values": [
+              "test_case",
+              "test_run",
+              "test_plan",
+              "shared_step"
+            ]
+          }
+        ],
+        "intent": "Merge one tag into another (v1). Admin-gated (tags_management).",
+        "responses": {
+          "200": {
+            "description": "Merge result.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/mv",
+        "mode": "write",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "new_base_folder_id",
+            "type": "integer",
+            "required": true,
+            "example": 123,
+            "description": "ID of the new parent folder (internal APIs)"
+          },
+          {
+            "name": "new_base_project_id",
+            "type": "integer",
+            "example": 456,
+            "description": "Optional destination project ID for cross-project moves"
+          },
+          {
+            "name": "user_action",
+            "type": "string",
+            "example": "move_folder"
+          }
+        ],
+        "intent": "Move a test case folder to a different parent folder",
+        "returns": [
+          "async",
+          "unique_id"
+        ],
+        "responses": {
+          "200": {
+            "description": "Folder moved successfully",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "folder": {
+                      "$schema": "Folder"
+                    },
+                    "source_path_folders": {
+                      "type": "array",
+                      "nullable": true,
+                      "items": {
+                        "$schema": "Folder"
+                      }
+                    },
+                    "destination_path_folders": {
+                      "type": "array",
+                      "items": {
+                        "$schema": "Folder"
+                      }
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "async": {
+                      "type": "boolean"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input or move not allowed",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/rename",
+        "mode": "write",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "description": "Name of the new folder.",
+            "json_path": "/folder/name"
+          },
+          {
+            "name": "notes",
+            "type": "string",
+            "description": "Description of the new folder.",
+            "json_path": "/folder/notes"
+          }
+        ],
+        "intent": "rename a folder in a project",
+        "returns": [
+          "request_trace_id"
+        ],
+        "responses": {
+          "200": {
+            "description": "Folder renamed successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "folder": {
+                      "$schema": "Folder"
+                    },
+                    "request_trace_id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "PATCH",
+        "path": "/api/v1/projects/{project_id}/folders/reorder",
+        "mode": "write",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "current",
+            "type": "array",
+            "required": true,
+            "example": [
+              21
+            ],
+            "description": "List of folder IDs to reorder"
+          },
+          {
+            "name": "prev",
+            "type": "integer",
+            "example": 101,
+            "description": "ID of the folder that will precede the moved folder"
+          },
+          {
+            "name": "next",
+            "type": "integer",
+            "example": 103,
+            "description": "ID of the folder that will follow the moved folder"
+          }
+        ],
+        "intent": "Reorder folders in a project",
+        "returns": [
+          "request_trace_id"
+        ],
+        "responses": {
+          "200": {
+            "description": "Folders reordered successfully",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Folders reordered successfully"
+                    }
+                  }
+                },
+                "request_trace_id": {
+                  "type": "string",
+                  "example": "xyz-123-trace"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "PATCH",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases/reorder",
+        "mode": "write",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "top_test_case",
+            "type": "string",
+            "description": "ID of the test case that will be above the moved ones.",
+            "json_path": "/re_order/top_test_case"
+          },
+          {
+            "name": "bottom_test_case",
+            "type": "string",
+            "description": "ID of the test case that will be below the moved ones.",
+            "json_path": "/re_order/bottom_test_case"
+          },
+          {
+            "name": "page",
+            "type": "integer",
+            "description": "Page number for paginated reordering.",
+            "json_path": "/re_order/page"
+          },
+          {
+            "name": "test_cases",
+            "type": "array",
+            "required": true,
+            "description": "Array of test case IDs to be moved.",
+            "json_path": "/re_order/test_cases"
+          }
+        ],
+        "intent": "Reorder test cases within a folder of a project",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Test cases reordered successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "test_cases": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "TestCase"
+                  }
+                },
+                "info": {
+                  "type": "object",
+                  "description": "Additional metadata about the reorder operation."
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/ai-duplicates",
+        "mode": "write",
+        "entity": "duplicate",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "duplicate_id",
+            "type": "integer",
+            "required": true,
+            "description": "The duplicate to resolve. Passed in the BODY, not the path."
+          },
+          {
+            "name": "merge_action",
+            "type": "string",
+            "required": true,
+            "description": "`merge` folds source into target; any other value archives."
+          },
+          {
+            "name": "source_testcase_id",
+            "type": "integer",
+            "description": "Required for merge — the case that will cease to exist independently."
+          },
+          {
+            "name": "target_testcase_id",
+            "type": "integer",
+            "description": "Required for merge — the case that survives."
+          }
+        ],
+        "intent": "Resolve a duplicate by MERGING or ARCHIVING — destroys or hides a test case",
+        "responses": {
+          "200": {
+            "description": "Duplicate resolved.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "description": "Duplicate not found, not in `suggested` status, or a test case id not part of it."
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-cases/{test_case_id}/histories/{history_id}/restore",
+        "mode": "write",
+        "entity": "version",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "history_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Restore a specific history entry",
+        "responses": {
+          "200": {
+            "description": "Successfully restored history entry",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/ai-duplicates/search-v2",
+        "mode": "read",
+        "entity": "duplicate",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "page",
+            "type": "integer"
+          },
+          {
+            "name": "duplicates",
+            "type": "string",
+            "description": "Duplicate-type filter."
+          },
+          {
+            "name": "owner",
+            "type": "string",
+            "description": "Owner tab — scopes to the caller's own duplicates vs all."
+          }
+        ],
+        "intent": "Filtered search over suggested duplicates",
+        "shape": "discovered",
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Matching suggested duplicates.",
+            "schema": {
+              "$schema": "V1DuplicatesListResponse"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/group/{entity_type}/tags",
+        "mode": "read",
+        "entity": "tag",
+        "path_params": [
+          {
+            "name": "entity_type",
+            "type": "string",
+            "required": true,
+            "values": [
+              "test_case",
+              "test_run"
+            ],
+            "example": "test_case"
+          }
+        ],
+        "query": [
+          {
+            "name": "q",
+            "type": "string"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          }
+        ],
+        "intent": "Search group tags for an entity type",
+        "returns": [
+          "name",
+          "created_at",
+          "usage_count"
+        ],
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "TagsSearchResponse"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/{entity}/search",
+        "mode": "read",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "entity",
+            "type": "string",
+            "required": true,
+            "values": [
+              "test-cases",
+              "test-runs",
+              "test-plans",
+              "reports"
+            ]
+          }
+        ],
+        "query": [
+          {
+            "name": "q[query]",
+            "type": "string",
+            "example": "tc"
+          },
+          {
+            "name": "q[folder_id]",
+            "type": "integer",
+            "example": 29529465
+          },
+          {
+            "name": "use_bstack_id",
+            "type": "string",
+            "values": [
+              "0",
+              "1"
+            ]
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "page_size",
+            "type": "integer"
+          },
+          {
+            "name": "include_test_plan",
+            "type": "boolean"
+          }
+        ],
+        "intent": "Search for entities within a project",
+        "shape": "discovered",
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Search results successfully retrieved",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "info": {
+                  "$schema": "PageInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/{entity}/search-v2",
+        "mode": "read",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "entity",
+            "type": "string",
+            "required": true,
+            "values": [
+              "test-cases",
+              "trtc",
+              "test-runs",
+              "test-plans"
+            ]
+          }
+        ],
+        "body": [
+          {
+            "name": "query",
+            "type": "string",
+            "example": "tc",
+            "description": "Search query string",
+            "json_path": "/q/query"
+          },
+          {
+            "name": "owner",
+            "type": "string",
+            "example": "14",
+            "json_path": "/q/owner"
+          },
+          {
+            "name": "reviewers",
+            "type": "string",
+            "example": "14,15",
+            "description": "Filter by reviewer, same form as `owner` — comma-separated TM user ids as a string, `$none` for none.",
+            "json_path": "/q/reviewers"
+          },
+          {
+            "name": "last_executed_by",
+            "type": "string",
+            "example": "14",
+            "description": "Filter by who last executed the case, same form as `owner`. A non-string value raises server-side rather than returning empty.",
+            "json_path": "/q/last_executed_by"
+          },
+          {
+            "name": "folder_id",
+            "type": "string",
+            "example": 29529465,
+            "description": "Filter by folder ID (single value or array)",
+            "json_path": "/q/folder_id"
+          },
+          {
+            "name": "folder_ids",
+            "type": "string",
+            "example": [
+              125382,
+              125385,
+              125386
+            ],
+            "description": "Filter by multiple folder IDs (comma-separated string or array)",
+            "json_path": "/q/folder_ids"
+          },
+          {
+            "name": "priority",
+            "type": "string",
+            "example": [
+              1268,
+              1270,
+              1269,
+              1267
+            ],
+            "description": "Filter by priority IDs (comma-separated string or array)",
+            "json_path": "/q/priority"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "description": "Filter by status IDs (comma-separated string or array)",
+            "json_path": "/q/status"
+          },
+          {
+            "name": "issue_type",
+            "type": "string",
+            "example": "jira",
+            "description": "Filter by issue type (e.g., jira, github)",
+            "json_path": "/q/issue_type"
+          },
+          {
+            "name": "issue_ids",
+            "type": "string",
+            "description": "Filter by issue IDs (comma-separated string or array)",
+            "json_path": "/q/issue_ids"
+          },
+          {
+            "name": "tags",
+            "type": "string",
+            "description": "Filter by tags (comma-separated string or array)",
+            "json_path": "/q/tags"
+          },
+          {
+            "name": "case_type",
+            "type": "string",
+            "description": "Filter by case-type option ids (comma-separated string or array).",
+            "json_path": "/q/case_type"
+          },
+          {
+            "name": "automation_state",
+            "type": "string",
+            "description": "Option ids, or the literals `automated` / `manual` which the server resolves.",
+            "json_path": "/q/automation_state"
+          },
+          {
+            "name": "automation_status",
+            "type": "string",
+            "description": "Filter by automation status.",
+            "json_path": "/q/automation_status"
+          },
+          {
+            "name": "review_status",
+            "type": "string",
+            "description": "Filter by review status (only meaningful where review/approval is configured).",
+            "json_path": "/q/review_status"
+          },
+          {
+            "name": "created_at",
+            "type": "string",
+            "example": "7_day",
+            "description": "Relative token `<n>_<unit>` with a SINGULAR unit (`day`, `hour`, `week`, `month`,\n`year`) — e.g. `7_day`, `24_hour`; `_gte` inverts it (`7_day_gte` = older than).\nAlso accepts `all_time` or an absolute `\"YYYY-MM-DD YYYY-MM-DD\"` range. A PLURAL\nunit such as `7_days` is an unhandled server error (500), not a 400.",
+            "json_path": "/q/created_at"
+          },
+          {
+            "name": "updated_at",
+            "type": "string",
+            "example": "1_month",
+            "description": "Same form as `created_at`.",
+            "json_path": "/q/updated_at"
+          },
+          {
+            "name": "date_range",
+            "type": "string",
+            "description": "Absolute created-at range as epoch milliseconds: `\"<epochMs>,<epochMs>\"`.",
+            "json_path": "/q/date_range"
+          },
+          {
+            "name": "ids",
+            "type": "string",
+            "description": "Fetch specific cases by integer id (comma-separated string or array).",
+            "json_path": "/q/ids"
+          },
+          {
+            "name": "is_archived",
+            "type": "boolean",
+            "description": "Restrict to archived (or non-archived) cases.",
+            "json_path": "/q/is_archived"
+          },
+          {
+            "name": "custom_fields",
+            "type": "object",
+            "example": {
+              "179720": [
+                "Yes"
+              ]
+            },
+            "json_path": "/q/custom_fields"
+          },
+          {
+            "name": "match",
+            "type": "object",
+            "example": {
+              "tags": "all",
+              "custom_fields": {
+                "179720": "none"
+              }
+            },
+            "description": "Per-field **operator** map — how to combine a field's values, NEVER the values\nthemselves. The value stays beside `match` under its own key; `match` only says\nhow to read it. A value placed inside `match` sets a meaningless operator and\napplies NO filter, which is the silent no-op described on `q`.\n\nAny filterable field may appear here, plus `custom_fields` keyed by field id.\nModes: `all`, `any`, ",
+            "json_path": "/q/match"
+          },
+          {
+            "name": "empty",
+            "type": "object",
+            "example": {
+              "system_fields": [
+                "priority"
+              ],
+              "custom_fields": [
+                "179720"
+              ]
+            },
+            "description": "Is-empty / is-unset filter. `system_fields` accepts the payload names `status`,\n`priority`, `case_type`, `automation_state`; `custom_fields` takes field ids.",
+            "fields": [
+              {
+                "name": "system_fields",
+                "type": "array"
+              },
+              {
+                "name": "custom_fields",
+                "type": "array"
+              }
+            ],
+            "json_path": "/q/empty"
+          },
+          {
+            "name": "p",
+            "type": "integer",
+            "example": 1,
+            "description": "Page number"
+          },
+          {
+            "name": "per_page",
+            "type": "integer",
+            "example": 5,
+            "description": "Results per page. Rows are large and vary with the data, so probe rather than assume: send p=1 with a moderate per_page and take the rows that actually come back as your ceiling (for entity=test-cases a row is ~40 keys / 5-9 KB, so start around 5). Then keep per_page FIXED for the whole walk — the offset is (p-1)*per_page, so changing it part-way shifts the window and SKIPS rows (page 1 at 5 then "
+          },
+          {
+            "name": "fields",
+            "type": "string",
+            "example": "owner,priority",
+            "description": "Comma-separated JOINED columns to hydrate (owner, tags, issues, reviewers, priority, status, case_type, automation_state, defects; unlisted names pass through). It selects joins ONLY — it can never remove the base fields (name, description, preconditions, steps, test_case_steps, custom_fields, attachments), so naming fewer changes how many rows fit per page, NOT the order of magnitude, and it cann",
+            "json_path": "/required/fields"
+          },
+          {
+            "name": "custom_fields",
+            "type": "string",
+            "example": "121,119",
+            "json_path": "/required/custom_fields"
+          },
+          {
+            "name": "result_custom_fields",
+            "type": "string",
+            "description": "Same idea for test-RESULT custom fields, on the result-bearing listings.",
+            "json_path": "/required/result_custom_fields"
+          }
+        ],
+        "intent": "Search for entities within a project (v2 - POST with body)",
+        "shape": "discovered",
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "description": "Search results successfully retrieved",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "info": {
+                  "$schema": "PageInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/users/search",
+        "mode": "read",
+        "entity": "user",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "q",
+            "type": "string"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "page_size",
+            "type": "integer"
+          }
+        ],
+        "intent": "Search users with access to a project",
+        "returns": [
+          "id",
+          "browserstack_user_id",
+          "customisable_dashboard_accessible",
+          "full_name",
+          "group_id",
+          "has_access",
+          "is_build_listing_enabled",
+          "is_delighted_visible",
+          "is_jira_app_project_panel_visible",
+          "is_lcnc_explore_dismissed",
+          "is_new_project_settings_visible",
+          "is_onboarding_project_header_visible"
+        ],
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "ProjectUsersSearchResponse"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/test-case/tags/search",
+        "mode": "read",
+        "entity": "tag",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "q",
+            "type": "string"
+          },
+          {
+            "name": "p",
+            "type": "integer"
+          },
+          {
+            "name": "page_size",
+            "type": "integer"
+          }
+        ],
+        "intent": "Search test case tags",
+        "returns": [
+          "name",
+          "created_at",
+          "usage_count"
+        ],
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "TagsSearchResponse"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          }
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases/search",
+        "mode": "read",
+        "entity": "test_case",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "query",
+            "type": "string"
+          },
+          {
+            "name": "use_bstack_id",
+            "type": "string",
+            "values": [
+              "0",
+              "1"
+            ]
+          }
+        ],
+        "intent": "Search test cases in a project",
+        "returns": [
+          "id",
+          "identifier",
+          "name",
+          "case_type_imported",
+          "comments_count",
+          "created_at",
+          "description",
+          "estimate",
+          "expected_result",
+          "history_count",
+          "is_automation",
+          "owner"
+        ],
+        "responses": {
+          "200": {
+            "description": "Test cases retrieved successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "test_cases": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "TestCase"
+                  }
+                },
+                "project_id": {
+                  "$schema": "Project"
+                },
+                "folder_id": {
+                  "$schema": "Folder"
+                },
+                "path_folders": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "Folder"
+                  }
+                },
+                "success": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/reports/{report_id}/send_email_now",
+        "mode": "write",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "report_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "emails",
+            "type": "array",
+            "example": [
+              "qa-leads@company.com"
+            ],
+            "description": "Recipient addresses. MUST be an array, even for one address."
+          },
+          {
+            "name": "file_type",
+            "type": "array",
+            "example": [
+              "pdf"
+            ],
+            "description": "Formats to attach. MUST be an array. Defaults to [\"pdf\"]."
+          }
+        ],
+        "intent": "Email a report immediately (async job).",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "`emails` or `file_type` was not an array."
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/undo-rm",
+        "mode": "write",
+        "entity": "folder",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Undo folder deletion",
+        "returns": [
+          "id",
+          "name",
+          "cases_count",
+          "group_id",
+          "is_automation",
+          "project_id",
+          "sub_folders_count",
+          "total_cases_count"
+        ],
+        "responses": {
+          "200": {
+            "description": "Folder successfully restored",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "folder": {
+                      "$schema": "Folder"
+                    },
+                    "path_folders": {
+                      "type": "array",
+                      "items": {
+                        "$schema": "Folder"
+                      }
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-plans/{test_plan_id}/test-runs/unlink",
+        "mode": "write",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_plan_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "test_runs",
+            "type": "array",
+            "required": true,
+            "description": "Integer run `uuid`s to unlink from this plan."
+          }
+        ],
+        "intent": "Unlink test runs from a test plan",
+        "responses": {
+          "200": {
+            "description": "`{\"success\": true}` on an unlink. Also returned with `{\"success\": false, \"error\":\n\"Please check test runs\"}` when `test_runs` is missing or not an array — a no-op.\n",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/admin-v2/settings/custom-fields/{custom_fields_id}/datasets/{dataset_id}/options/{option_id}/update",
+        "mode": "write",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "dataset_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "option_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "custom_fields_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "option_value",
+            "type": "string",
+            "required": true,
+            "description": "The option label."
+          },
+          {
+            "name": "is_default",
+            "type": "boolean",
+            "required": true,
+            "description": "REQUIRED — a missing value is a 400. Must be false for every option of a multi_dropdown; at most one true for a dropdown."
+          },
+          {
+            "name": "parent_option_id",
+            "type": "integer",
+            "description": "For nested_dropdown children only — the parent option this hangs under."
+          }
+        ],
+        "intent": "Rename an option or change its default (POST to /update).",
+        "responses": {
+          "200": {
+            "description": "The updated option under `data`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/admin-v2/settings/custom-fields/{custom_fields_id}/datasets/{dataset_id}/project-mappings/update",
+        "mode": "write",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "dataset_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "custom_fields_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "link_projects",
+            "type": "array",
+            "description": "Project INTEGER ids to ADD. Note the spelling — not `linked_projects`."
+          },
+          {
+            "name": "unlink_projects",
+            "type": "array",
+            "description": "Project INTEGER ids to REMOVE. Destroys their stored values."
+          },
+          {
+            "name": "link_to_future_projects",
+            "type": "boolean"
+          },
+          {
+            "name": "select_all",
+            "type": "boolean",
+            "description": "Apply to every project; may switch the call to async."
+          }
+        ],
+        "intent": "Link or unlink projects for a dataset — how you change which projects see a field.",
+        "responses": {
+          "200": {
+            "description": "The updated dataset under `data`, or an async acknowledgement.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/admin-v2/settings/custom-fields/{custom_fields_id}/update",
+        "mode": "write",
+        "entity": "custom_field",
+        "path_params": [
+          {
+            "name": "custom_fields_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "field_name",
+            "type": "string",
+            "required": true,
+            "description": "Display label. Editable. REQUIRED even when unchanged."
+          },
+          {
+            "name": "field_type",
+            "type": "string",
+            "required": true,
+            "description": "REQUIRED for validation, but any change is silently ignored."
+          },
+          {
+            "name": "is_required",
+            "type": "boolean",
+            "required": true,
+            "description": "REQUIRED — omitting it is a 400."
+          },
+          {
+            "name": "entity_type",
+            "type": "string"
+          },
+          {
+            "name": "place_holder_text",
+            "type": "string"
+          },
+          {
+            "name": "default_value",
+            "type": "string",
+            "description": "Only applied when `field_type` is `boolean`."
+          }
+        ],
+        "intent": "Update a field definition's label, requiredness or placeholder (POST to /update).",
+        "responses": {
+          "200": {
+            "description": "The updated definition under `data`.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "PUT",
+        "path": "/api/v1/projects/{project_id}/datasets/{uuid}",
+        "mode": "write",
+        "entity": "dataset",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "uuid",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "Updated name of the dataset.",
+            "json_path": "/dataset/name"
+          },
+          {
+            "name": "variables",
+            "type": "array",
+            "description": "Updated list of dataset variables/columns (max 40).",
+            "fields": [
+              {
+                "name": "name",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "uuid",
+                "type": "string"
+              }
+            ],
+            "json_path": "/dataset/variables"
+          },
+          {
+            "name": "rows",
+            "type": "array",
+            "description": "Updated list of dataset rows (max 100).",
+            "fields": [
+              {
+                "name": "row_number",
+                "type": "integer",
+                "required": true
+              },
+              {
+                "name": "row_data",
+                "type": "array",
+                "required": true
+              },
+              {
+                "name": "uuid",
+                "type": "string"
+              }
+            ],
+            "json_path": "/dataset/rows"
+          }
+        ],
+        "intent": "Update a dataset.",
+        "returns": [
+          "name",
+          "created_at",
+          "rows_count",
+          "uuid"
+        ],
+        "responses": {
+          "200": {
+            "description": "Dataset updated successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "description": "Indicates if the update was successful.",
+                  "example": true
+                },
+                "dataset": {
+                  "$schema": "Dataset"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "PATCH",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions/{session_id}",
+        "mode": "write",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "type": "integer",
+            "required": true,
+            "example": 123
+          }
+        ],
+        "body": [
+          {
+            "name": "title",
+            "type": "string",
+            "example": "Updated checkout exploration",
+            "description": "New title for the session.",
+            "json_path": "/exploratory_session/title"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "description": "Updated description.",
+            "json_path": "/exploratory_session/description"
+          },
+          {
+            "name": "charter",
+            "type": "string",
+            "description": "Updated testing charter.",
+            "json_path": "/exploratory_session/charter"
+          },
+          {
+            "name": "timebox_duration",
+            "type": "integer",
+            "example": 90,
+            "description": "Updated planned duration in minutes.",
+            "json_path": "/exploratory_session/timebox_duration"
+          },
+          {
+            "name": "duration",
+            "type": "integer",
+            "example": 45,
+            "description": "Tracked duration in minutes.",
+            "json_path": "/exploratory_session/duration"
+          },
+          {
+            "name": "actual_duration",
+            "type": "integer",
+            "example": 50,
+            "description": "Final actual duration in minutes.",
+            "json_path": "/exploratory_session/actual_duration"
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "example": 789,
+            "description": "Move the session to a different folder.",
+            "json_path": "/exploratory_session/folder_id"
+          },
+          {
+            "name": "owner",
+            "type": "integer",
+            "example": 55,
+            "description": "TCM user ID of the new owner / assignee.",
+            "json_path": "/exploratory_session/owner"
+          },
+          {
+            "name": "assignee",
+            "type": "integer",
+            "example": 55,
+            "description": "Alias for `owner`.",
+            "json_path": "/exploratory_session/assignee"
+          },
+          {
+            "name": "tags",
+            "type": "array",
+            "example": [
+              "smoke",
+              "payment"
+            ],
+            "description": "Replace the session's tags with this list.",
+            "json_path": "/exploratory_session/tags"
+          },
+          {
+            "name": "configurations",
+            "type": "array",
+            "example": [
+              2,
+              4
+            ],
+            "description": "Replace the session's configuration IDs.",
+            "json_path": "/exploratory_session/configurations"
+          },
+          {
+            "name": "attachments",
+            "type": "array",
+            "description": "Updated set of blob / media attachment IDs.",
+            "json_path": "/exploratory_session/attachments"
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "description": "Replace the linked issues for this session.",
+            "fields": [
+              {
+                "name": "issue_id",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "issue_type",
+                "type": "string",
+                "required": true
+              }
+            ],
+            "json_path": "/exploratory_session/issues"
+          }
+        ],
+        "intent": "Update an exploratory session",
+        "returns": [
+          "id",
+          "title",
+          "actual_duration",
+          "charter",
+          "created_at",
+          "description",
+          "duration",
+          "folder_id",
+          "session_log_count",
+          "session_state",
+          "timebox_duration",
+          "updated_at"
+        ],
+        "responses": {
+          "200": {
+            "description": "Exploratory session updated successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "exploratory_session": {
+                  "$schema": "ExploratorySession"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "PATCH",
+        "path": "/api/v1/projects/{project_id}/exploratory-sessions/{session_id}/logs/{log_id}",
+        "mode": "write",
+        "entity": "exploratory_session",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "type": "integer",
+            "required": true,
+            "example": 123
+          },
+          {
+            "name": "log_id",
+            "type": "integer",
+            "required": true,
+            "example": 789
+          }
+        ],
+        "body": [
+          {
+            "name": "content",
+            "type": "string",
+            "example": "<p>Confirmed the spinner issue on iOS 17 as well.</p>",
+            "description": "Updated rich-text HTML content of the log entry.",
+            "json_path": "/session_log/content"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "values": [
+              "pass",
+              "fail",
+              "bug",
+              "retest",
+              "block",
+              "note"
+            ],
+            "example": "fail",
+            "description": "Updated test result status.",
+            "json_path": "/session_log/status"
+          },
+          {
+            "name": "elapsed_time",
+            "type": "integer",
+            "example": 180,
+            "description": "Updated elapsed time in seconds.",
+            "json_path": "/session_log/elapsed_time"
+          },
+          {
+            "name": "defects",
+            "type": "array",
+            "description": "Replace the linked defects for this log entry.",
+            "fields": [
+              {
+                "name": "issue_id",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "issue_type",
+                "type": "string",
+                "required": true
+              }
+            ],
+            "json_path": "/session_log/defects"
+          }
+        ],
+        "intent": "Update a session log entry",
+        "returns": [
+          "id",
+          "status",
+          "content",
+          "created_at",
+          "elapsed_time",
+          "session_id",
+          "updated_at"
+        ],
+        "responses": {
+          "200": {
+            "description": "Session log updated successfully.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "session_log": {
+                  "$schema": "ExploratorySessionLog"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/filter/{filter_id}",
+        "mode": "write",
+        "entity": "filter",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "filter_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "description": "Name of the filter"
+          },
+          {
+            "name": "entity",
+            "type": "string",
+            "required": true,
+            "values": [
+              "testcase",
+              "testplan",
+              "testrun",
+              "exploratory_session",
+              "test_plan_test_case"
+            ],
+            "description": "Entity type the filter applies to. The server's validator accepts five values (the\nlast two were missing here); an unlisted value returns 400 \"Invalid JSON data\"."
+          },
+          {
+            "name": "is_project_level",
+            "type": "boolean",
+            "description": "Whether this filter is available at project level"
+          },
+          {
+            "name": "filters",
+            "type": "object",
+            "description": "Filter criteria object containing the actual filter conditions"
+          }
+        ],
+        "intent": "Update a filter",
+        "returns": [
+          "id",
+          "name",
+          "created_at",
+          "entity_type",
+          "is_project_level",
+          "owner",
+          "project_id",
+          "updated_at"
+        ],
+        "responses": {
+          "200": {
+            "$response": "FilterUpdateResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "PATCH",
+        "path": "/api/v1/projects/{project_id}/test-runs/{test_run_id}/test-cases/{test_case_id}/test-results",
+        "mode": "write",
+        "entity": "result",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_run_id",
+            "type": "string",
+            "required": true,
+            "example": "TR-14"
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "query": [
+          {
+            "name": "configuration_id",
+            "type": "string"
+          },
+          {
+            "name": "mapping_id",
+            "type": "string"
+          }
+        ],
+        "body": [
+          {
+            "name": "status_id",
+            "type": "integer",
+            "description": "Result status id (resolve via the statuses-and-states concept — these are ids, not names).",
+            "json_path": "/test_result/status_id"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "description": "Rich text description of the test result.",
+            "json_path": "/test_result/description"
+          },
+          {
+            "name": "custom_fields",
+            "type": "object",
+            "json_path": "/test_result/custom_fields"
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "description": "Linked defects. Each entry is an OBJECT — a bare string is silently dropped by the server's parameter filter, so the issue link is never created and no error is returned.",
+            "fields": [
+              {
+                "name": "issue_id",
+                "type": "string"
+              },
+              {
+                "name": "issue_type",
+                "type": "string"
+              }
+            ],
+            "json_path": "/test_result/issues"
+          },
+          {
+            "name": "attachments",
+            "type": "array",
+            "json_path": "/test_result/attachments"
+          },
+          {
+            "name": "elapsed_time",
+            "type": "integer",
+            "json_path": "/test_result/elapsed_time"
+          },
+          {
+            "name": "configuration_id",
+            "type": "integer",
+            "description": "Which configuration's result to patch. TOP level — the server does not read it from inside `test_result`."
+          },
+          {
+            "name": "mapping_id",
+            "type": "integer",
+            "description": "Target a specific run/case mapping. Top level."
+          }
+        ],
+        "intent": "Update the latest test result",
+        "returns": [
+          "id",
+          "name",
+          "byte_size",
+          "checksum",
+          "content_type",
+          "download_url",
+          "key",
+          "product_id",
+          "size",
+          "url"
+        ],
+        "responses": {
+          "200": {
+            "description": "Test result successfully updated",
+            "schema": {
+              "$schema": "TestResult"
+            }
+          },
+          "400": {
+            "description": "Bad request - Test run is closed or invalid parameters",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "status": {
+                  "type": "integer",
+                  "example": 400
+                },
+                "error": {
+                  "type": "string",
+                  "example": "Cannot Update Closed Test Run"
+                }
+              }
+            }
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "description": "No test results found",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "status": {
+                  "type": "integer",
+                  "example": 404
+                },
+                "message": {
+                  "type": "string",
+                  "example": "No test results found"
+                }
+              }
+            }
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/settings",
+        "mode": "write",
+        "entity": "project",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Update project settings",
+        "responses": {
+          "200": {
+            "description": "Project settings successfully updated",
+            "schema": {
+              "type": "object",
+              "required": [
+                "success",
+                "project_settings"
+              ],
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "project_settings": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          }
+        }
+      },
+      {
+        "method": "PATCH",
+        "path": "/api/v1/projects/{project_id}/reports/{report_id}",
+        "mode": "write",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "report_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "projectId",
+            "type": "integer",
+            "example": 10000
+          },
+          {
+            "name": "report_type",
+            "type": "string",
+            "required": true,
+            "values": [
+              "Test Run Summary",
+              "Test Run Detailed Report",
+              "Test Plan Summary",
+              "Requirement Traceability Report",
+              "Test Case Activity",
+              "Exploratory Session Summary",
+              "User Workload Report",
+              "Defects Summary",
+              "Defects Detailed Report"
+            ],
+            "example": "Test Run Summary",
+            "description": "Report type, sent as its DISPLAY NAME (not a machine slug).\n\nSeven types produce data. `Defects Summary` and `Defects Detailed Report` are\naccepted on create/update but have no data branch on the server, so such a report\nalways reads back with `report_data: null` — never offer them as a way to report\non defects (use `Test Run Summary`, whose sections include `issues_by_priority` /\n`issues_by_statu"
+          },
+          {
+            "name": "title",
+            "type": "string",
+            "example": "Updated Title"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "example": ""
+          },
+          {
+            "name": "report_timeframe",
+            "type": "string",
+            "required": true,
+            "values": [
+              "last_one_day",
+              "last_one_week",
+              "last_one_month",
+              "last_three_months",
+              "custom",
+              "specific_test_runs",
+              "specific_test_plans",
+              "specific_test_cases",
+              "specific_sessions",
+              "requirements"
+            ],
+            "example": "last_one_week",
+            "description": "The window a report covers. Also the value of the `reportTimeRange` query param\non the report-detail read.\n\nThe four relative windows compute a date range from \"now\". `custom` computes it\nfrom `custom_date_range` and **requires** that field — sending `custom` without it\nis an unhandled server error, not a 422.\n\nThe five remaining values carry no dates; they select entities through\n`report_filters`"
+          },
+          {
+            "name": "report_creation_mode",
+            "type": "string",
+            "required": true,
+            "values": [
+              "custom_report",
+              "system_generated"
+            ],
+            "example": "custom_report"
+          },
+          {
+            "name": "test_run",
+            "type": "object",
+            "fields": [
+              {
+                "name": "created_at",
+                "type": "string",
+                "required": true
+              },
+              {
+                "name": "status",
+                "type": "array",
+                "required": true
+              },
+              {
+                "name": "owner",
+                "type": "array",
+                "required": true
+              },
+              {
+                "name": "automation_status",
+                "type": "array",
+                "required": true
+              },
+              {
+                "name": "type",
+                "type": "array",
+                "required": true
+              }
+            ],
+            "json_path": "/dynamic_filters/test_run"
+          },
+          {
+            "name": "status",
+            "type": "array",
+            "json_path": "/report_filters/status"
+          },
+          {
+            "name": "priority",
+            "type": "array",
+            "json_path": "/report_filters/priority"
+          },
+          {
+            "name": "case_type",
+            "type": "array",
+            "json_path": "/report_filters/case_type"
+          },
+          {
+            "name": "assignee",
+            "type": "array",
+            "json_path": "/report_filters/assignee"
+          },
+          {
+            "name": "automation_status",
+            "type": "array",
+            "json_path": "/report_filters/automation_status"
+          },
+          {
+            "name": "automation_state",
+            "type": "array",
+            "json_path": "/report_filters/automation_state"
+          },
+          {
+            "name": "test_runs",
+            "type": "array",
+            "description": "Integer run ids — pairs with report_timeframe=specific_test_runs.",
+            "json_path": "/report_filters/test_runs"
+          },
+          {
+            "name": "test_plans",
+            "type": "array",
+            "description": "Integer plan ids — pairs with report_timeframe=specific_test_plans.",
+            "json_path": "/report_filters/test_plans"
+          },
+          {
+            "name": "test_cases",
+            "type": "string",
+            "description": "Case selection — pairs with report_timeframe=specific_test_cases. FOLDER-KEYED\n(see SelectionData), never a flat id list: the server resolves the selection\nthrough its folder map, so any other shape yields zero cases and saves an\nUNSCOPED, project-wide report at 200.\n\nSend all three keys. Folder ids are STRING keys; test-case ids are INTEGERS\n(the numeric `id`, not the TC-NNN identifier) — take bo",
+            "fields": [
+              {
+                "name": "select_all",
+                "type": "boolean",
+                "required": true
+              },
+              {
+                "name": "folders",
+                "type": "object",
+                "required": true
+              },
+              {
+                "name": "unique_test_case_count",
+                "type": "integer",
+                "required": true
+              }
+            ],
+            "json_path": "/report_filters/test_cases"
+          },
+          {
+            "name": "session_ids",
+            "type": "array",
+            "description": "Exploratory session ids — pairs with report_timeframe=specific_sessions.",
+            "json_path": "/report_filters/session_ids"
+          },
+          {
+            "name": "requirements",
+            "type": "object",
+            "description": "{ issue_type: [issue_id, ...] } — pairs with report_timeframe=requirements.",
+            "json_path": "/report_filters/requirements"
+          },
+          {
+            "name": "test_plan_selection",
+            "type": "object",
+            "description": "Per-plan sub-plan selection: { plan_id: { select_all, selected_sub_plan_ids, deselected_sub_plan_ids } }.",
+            "json_path": "/report_filters/test_plan_selection"
+          },
+          {
+            "name": "builds",
+            "type": "array",
+            "json_path": "/report_filters/builds"
+          },
+          {
+            "name": "projects",
+            "type": "array",
+            "json_path": "/report_filters/projects"
+          },
+          {
+            "name": "folder",
+            "type": "array",
+            "json_path": "/report_filters/folder"
+          },
+          {
+            "name": "test_case_tags",
+            "type": "array",
+            "json_path": "/report_filters/test_case_tags"
+          },
+          {
+            "name": "tc_custom_fields",
+            "type": "object",
+            "description": "Keyed by custom-field id (an OBJECT, not an array). ONLY consumed for\n`Test Run Summary`, `Test Run Detailed Report` and `Test Case Activity` — on\nthe other six report types the server never reads it and drops it silently.\nPersisted (and read back) under the name `custom_fields`.",
+            "json_path": "/report_filters/tc_custom_fields"
+          },
+          {
+            "name": "custom_date_range",
+            "type": "string",
+            "example": "2025-04-16 2025-04-24",
+            "description": "\"YYYY-MM-DD YYYY-MM-DD\" (space-separated). REQUIRED whenever report_timeframe is `custom`."
+          },
+          {
+            "name": "users",
+            "type": "array",
+            "json_path": "/mail_to/users"
+          },
+          {
+            "name": "external_mails",
+            "type": "array",
+            "json_path": "/mail_to/external_mails"
+          },
+          {
+            "name": "frequency",
+            "type": "string",
+            "values": [
+              "daily",
+              "weekly",
+              "monthly"
+            ],
+            "example": "weekly",
+            "description": "Scheduling cadence. Send `frequency` and `frequency_details` TOGETHER, or omit\nBOTH — omitting both creates a valid unscheduled, on-demand report.\n\nTwo consequences of omitting them: `mail_to` is only persisted for scheduled\nreports (recipients on an unscheduled report are silently dropped), and\n`next_run_at` stays null.\n\nThere is no `once` value — the server's cadence enum is daily/weekly/monthly"
+          },
+          {
+            "name": "time",
+            "type": "string",
+            "example": "08:00",
+            "description": "24-hour HH:MM, UTC.",
+            "json_path": "/frequency_details/time"
+          },
+          {
+            "name": "day",
+            "type": "string",
+            "example": "monday",
+            "description": "Required for weekly (lowercase day name) and monthly (integer 1-28).\nOmit for daily.",
+            "json_path": "/frequency_details/day"
+          }
+        ],
+        "intent": "Update a scheduled report",
+        "returns": [
+          "id",
+          "identifier",
+          "title",
+          "created_at",
+          "custom_date_range",
+          "description",
+          "frequency",
+          "group_id",
+          "next_run_at",
+          "project_id",
+          "report_creation_mode",
+          "report_timeframe"
+        ],
+        "responses": {
+          "200": {
+            "$response": "UpdateReportResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "PATCH",
+        "path": "/api/v1/projects/{project_id}/shared-steps/{shared_step_id}",
+        "mode": "write",
+        "entity": "shared_step",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "shared_step_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "title",
+            "type": "string",
+            "required": true,
+            "description": "Title of the shared step"
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "description": "ID of the shared-field folder to move the shared step into. Null moves it to the root (Unassigned)."
+          },
+          {
+            "name": "shared_step_details",
+            "type": "array",
+            "required": true,
+            "fields": [
+              {
+                "name": "id",
+                "type": "integer"
+              },
+              {
+                "name": "step",
+                "type": "string"
+              },
+              {
+                "name": "result",
+                "type": "string"
+              },
+              {
+                "name": "order",
+                "type": "integer"
+              },
+              {
+                "name": "test_data",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "intent": "Update a shared step",
+        "returns": [
+          "id",
+          "title"
+        ],
+        "responses": {
+          "200": {
+            "$response": "SharedStepsIDResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/test-plans/{test_plan_id}/update",
+        "mode": "write",
+        "entity": "test_plan",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_plan_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "name",
+            "type": "string",
+            "json_path": "/test_plan/name"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "json_path": "/test_plan/description"
+          },
+          {
+            "name": "start_date",
+            "type": "string",
+            "description": "ISO-8601 date.",
+            "json_path": "/test_plan/start_date"
+          },
+          {
+            "name": "end_date",
+            "type": "string",
+            "description": "ISO-8601 date.",
+            "json_path": "/test_plan/end_date"
+          },
+          {
+            "name": "plan_status",
+            "type": "string",
+            "description": "Plan status. The list filter accepts new / started / completed.",
+            "json_path": "/test_plan/plan_status"
+          },
+          {
+            "name": "owner",
+            "type": "integer",
+            "description": "Owner user id — resolve via the project users read first.",
+            "json_path": "/test_plan/owner"
+          },
+          {
+            "name": "parent_plan_id",
+            "type": "integer",
+            "description": "Parent plan's INTEGER id. Set it to create (or re-parent into) a SUB-plan — the\nresult carries an STP-NNN identifier. Null/omitted means a top-level plan.",
+            "json_path": "/test_plan/parent_plan_id"
+          },
+          {
+            "name": "tags",
+            "type": "array",
+            "json_path": "/test_plan/tags"
+          },
+          {
+            "name": "reviewers",
+            "type": "array",
+            "description": "Reviewer user ids.",
+            "json_path": "/test_plan/reviewers"
+          },
+          {
+            "name": "attachments",
+            "type": "array",
+            "description": "Attachment ids already uploaded via the attachments surface.",
+            "json_path": "/test_plan/attachments"
+          },
+          {
+            "name": "custom_fields",
+            "type": "object",
+            "json_path": "/test_plan/custom_fields"
+          },
+          {
+            "name": "issues",
+            "type": "array",
+            "description": "Linked tracker issues. Structured — NOT a flat array of keys.",
+            "fields": [
+              {
+                "name": "issue_id",
+                "type": "string"
+              },
+              {
+                "name": "issue_type",
+                "type": "string"
+              },
+              {
+                "name": "metadata",
+                "type": "object"
+              }
+            ],
+            "json_path": "/test_plan/issues"
+          },
+          {
+            "name": "test_runs",
+            "type": "string",
+            "description": "The plan's linked test runs. Accepts EITHER an array of test-run integer ids, OR a\nbulk-selection object for \"every run matching this filter\". On update this REPLACES\nthe existing link set rather than appending.",
+            "json_path": "/test_plan/test_runs"
+          }
+        ],
+        "intent": "Update a test plan (or sub-plan)",
+        "responses": {
+          "200": {
+            "description": "The updated plan.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/generic/attachments/ai_uploads",
+        "mode": "write",
+        "entity": "attachment",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Upload AI-generated or AI-processed attachments",
+        "returns": [
+          "id",
+          "name",
+          "content_type",
+          "download_url",
+          "size",
+          "url"
+        ],
+        "responses": {
+          "201": {
+            "$response": "GenericAttachmentsResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/generic/attachments",
+        "mode": "write",
+        "entity": "attachment",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Upload generic attachments to a project from rich text editor or other sources",
+        "returns": [
+          "id",
+          "name",
+          "content_type",
+          "download_url",
+          "size",
+          "url"
+        ],
+        "responses": {
+          "201": {
+            "$response": "GenericAttachmentsResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases/{test_case_id}/attachments",
+        "mode": "write",
+        "entity": "attachment",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "folder_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "test_case_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "intent": "Upload one or more attachments to a test case",
+        "returns": [
+          "id",
+          "byte_size",
+          "content_type",
+          "filename"
+        ],
+        "responses": {
+          "200": {
+            "description": "Attachments uploaded successfully",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "attachments": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "AttachmentResponse"
+                  }
+                },
+                "success": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "422": {
+            "$response": "UnprocessableEntity"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      },
+      {
+        "method": "POST",
+        "path": "/api/v1/projects/{project_id}/reports/{report_id}/drilldown",
+        "mode": "read",
+        "entity": "report",
+        "path_params": [
+          {
+            "name": "project_id",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "report_id",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "body": [
+          {
+            "name": "user_id",
+            "type": "integer",
+            "required": true,
+            "example": 12345,
+            "description": "BrowserStack user id whose per-test-case / per-run / per-day breakdown is requested."
+          },
+          {
+            "name": "p",
+            "type": "integer",
+            "example": 1,
+            "description": "Page number for paginated drill-down rows."
+          },
+          {
+            "name": "per_page",
+            "type": "integer",
+            "example": 50,
+            "description": "Number of rows per page."
+          }
+        ],
+        "intent": "Fetch the User Workload drill-down for a single user",
+        "shape": "discovered",
+        "max_page_size": 100,
+        "paginated": true,
+        "responses": {
+          "200": {
+            "$response": "ReportSummaryResponse"
+          },
+          "400": {
+            "$response": "BadRequest"
+          },
+          "401": {
+            "$response": "Unauthorized"
+          },
+          "403": {
+            "$response": "Forbidden"
+          },
+          "404": {
+            "$response": "NotFound"
+          },
+          "500": {
+            "$response": "InternalServerError"
+          }
+        }
+      }
+    ],
+    "schemas": {
+      "TestRun": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "TR-17"
+          },
+          "uuid": {
+            "type": "integer",
+            "example": 17
+          },
+          "identifier": {
+            "type": "string",
+            "example": "TR-17"
+          },
+          "name": {
+            "type": "string",
+            "example": "Test Run1-20/05/2025"
+          },
+          "type": {
+            "type": "string",
+            "example": "TestRun"
+          },
+          "description": {
+            "type": "string",
+            "example": ""
+          },
+          "owner": {
+            "type": "integer",
+            "example": 2
+          },
+          "assignee": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "browserstack_user_id": {
+                "type": "integer"
+              },
+              "full_name": {
+                "type": "string"
+              },
+              "group_id": {
+                "type": "integer"
+              },
+              "onboarded": {
+                "type": "integer"
+              }
+            }
+          },
+          "environment": {
+            "type": "string",
+            "nullable": true
+          },
+          "overall_progress": {
+            "type": "object",
+            "properties": {
+              "untested": {
+                "type": "integer"
+              },
+              "passed": {
+                "type": "integer"
+              },
+              "retest": {
+                "type": "integer"
+              },
+              "failed": {
+                "type": "integer"
+              },
+              "blocked": {
+                "type": "integer"
+              },
+              "skipped": {
+                "type": "integer"
+              },
+              "in_progress": {
+                "type": "integer"
+              }
+            }
+          },
+          "overall_progress_by_status_id": {
+            "type": "object"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "type": "string"
+              },
+              "detail": {
+                "type": "string"
+              }
+            }
+          },
+          "test_cases_count": {
+            "type": "integer"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "run_state": {
+            "type": "string",
+            "enum": [
+              "new_run",
+              "in_progress",
+              "under_review",
+              "rejected",
+              "done",
+              "closed"
+            ]
+          },
+          "active_state": {
+            "type": "string",
+            "enum": [
+              "active",
+              "closed"
+            ]
+          },
+          "is_automation": {
+            "type": "boolean"
+          },
+          "observability_url": {
+            "type": "string",
+            "nullable": true
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "configurations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "assignee_imported": {
+            "type": "boolean"
+          },
+          "is_dynamic": {
+            "type": "boolean"
+          },
+          "test_plans": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "self_ui_link": {
+            "type": "string"
+          }
+        }
+      },
+      "Project": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the project."
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unique ID for the project."
+          },
+          "description": {
+            "type": "string",
+            "description": "A brief description of the project."
+          },
+          "identifier": {
+            "type": "string",
+            "description": "A short unique identifier (e.g., PR-674)."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp indicating when the project was created."
+          },
+          "import_id": {
+            "type": "string",
+            "description": "An optional import identifier. May be null.",
+            "example": null,
+            "nullable": true
+          },
+          "test_cases_count": {
+            "type": "integer",
+            "description": "Number of test cases under the project."
+          },
+          "test_runs_count": {
+            "type": "integer",
+            "description": "Number of test runs under the project."
+          },
+          "links": {
+            "type": "object",
+            "description": "Links related to the project.",
+            "properties": {
+              "repository": {
+                "type": "string",
+                "description": "Endpoint for the project's repository."
+              },
+              "self": {
+                "type": "string",
+                "description": "Endpoint for the project itself."
+              },
+              "test_runs": {
+                "type": "string",
+                "description": "Endpoint for the project's test runs."
+              },
+              "users": {
+                "type": "string",
+                "description": "Endpoint for the users associated with this project."
+              }
+            }
+          },
+          "project_creator": {
+            "type": "boolean",
+            "description": "Indicates whether the current user is the creator of the project."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "description": "Standard error response format.",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Application-specific error code.",
+                "example": "ERR_INVALID_PARAMS"
+              },
+              "message": {
+                "type": "string",
+                "description": "Human-readable error message.",
+                "example": "The provided parameters are invalid."
+              },
+              "details": {
+                "type": "object",
+                "description": "Optional field with additional error details."
+              }
+            }
+          }
+        }
+      },
+      "V1TestPlanBulkResponse": {
+        "type": "object",
+        "description": "Dual-shape response. Below the bulk threshold the work is done and you get\n`plans` + `count`. Above it the work was handed to a background job and you get\n`async: true` + `unique_id` — the plans are NOT changed yet at that point; re-read to\nconfirm (see the async-jobs concept).\n",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "async": {
+            "type": "boolean",
+            "description": "Present and true only when the operation was dispatched asynchronously."
+          },
+          "unique_id": {
+            "type": "string",
+            "description": "Correlation id of the async job. Present only when async is true."
+          },
+          "plans": {
+            "type": "array",
+            "description": "Affected plans. Present only on the synchronous path.",
+            "items": {
+              "type": "object"
+            }
+          },
+          "count": {
+            "type": "integer",
+            "description": "Number of affected plans. Present only on the synchronous path."
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique identifier for the user."
+          },
+          "browserstack_user_id": {
+            "type": "integer",
+            "description": "BrowserStack user ID associated with this user."
+          },
+          "full_name": {
+            "type": "string",
+            "description": "Full name of the user."
+          },
+          "email": {
+            "type": "string",
+            "description": "Email address of the user."
+          },
+          "group_id": {
+            "type": "integer",
+            "description": "Group ID the user belongs to."
+          },
+          "onboarded": {
+            "type": "integer",
+            "description": "Onboarding status of the user."
+          },
+          "reports_and_notification_enabled": {
+            "type": "boolean",
+            "description": "Indicates if reports and notifications are enabled for the user."
+          }
+        }
+      },
+      "TestCaseStep": {
+        "type": "object",
+        "properties": {
+          "background": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "feature": {
+            "type": "string",
+            "nullable": true
+          },
+          "hashed_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "project_id": {
+            "type": "integer"
+          },
+          "result": {
+            "type": "string"
+          },
+          "scenario": {
+            "type": "string",
+            "nullable": true
+          },
+          "sharedStep": {
+            "type": "string",
+            "nullable": true
+          },
+          "shared_step_detail_id": {
+            "type": "integer",
+            "nullable": true
+          },
+          "shared_step_id": {
+            "type": "integer",
+            "nullable": true
+          },
+          "step": {
+            "type": "string"
+          },
+          "test_case_id": {
+            "type": "integer"
+          },
+          "test_data": {
+            "type": "string",
+            "nullable": true
+          },
+          "test_recording_id": {
+            "type": "integer",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "TestCase": {
+        "type": "object",
+        "properties": {
+          "assignee": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "Unique identifier for the user."
+              },
+              "browserstack_user_id": {
+                "type": "integer",
+                "description": "BrowserStack user ID associated with this user."
+              },
+              "full_name": {
+                "type": "string",
+                "description": "Full name of the user."
+              },
+              "email": {
+                "type": "string",
+                "description": "Email address of the user."
+              },
+              "group_id": {
+                "type": "integer",
+                "description": "Group ID the user belongs to."
+              },
+              "onboarded": {
+                "type": "integer",
+                "description": "Onboarding status of the user."
+              },
+              "reports_and_notification_enabled": {
+                "type": "boolean",
+                "description": "Indicates if reports and notifications are enabled for the user."
+              }
+            }
+          },
+          "creator_details": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "Unique identifier for the user."
+              },
+              "browserstack_user_id": {
+                "type": "integer",
+                "description": "BrowserStack user ID associated with this user."
+              },
+              "full_name": {
+                "type": "string",
+                "description": "Full name of the user."
+              },
+              "email": {
+                "type": "string",
+                "description": "Email address of the user."
+              },
+              "group_id": {
+                "type": "integer",
+                "description": "Group ID the user belongs to."
+              },
+              "onboarded": {
+                "type": "integer",
+                "description": "Onboarding status of the user."
+              },
+              "reports_and_notification_enabled": {
+                "type": "boolean",
+                "description": "Indicates if reports and notifications are enabled for the user."
+              }
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updator_details": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "Unique identifier for the user."
+              },
+              "browserstack_user_id": {
+                "type": "integer",
+                "description": "BrowserStack user ID associated with this user."
+              },
+              "full_name": {
+                "type": "string",
+                "description": "Full name of the user."
+              },
+              "email": {
+                "type": "string",
+                "description": "Email address of the user."
+              },
+              "group_id": {
+                "type": "integer",
+                "description": "Group ID the user belongs to."
+              },
+              "onboarded": {
+                "type": "integer",
+                "description": "Onboarding status of the user."
+              },
+              "reports_and_notification_enabled": {
+                "type": "boolean",
+                "description": "Indicates if reports and notifications are enabled for the user."
+              }
+            }
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "case_type": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "internal_name": {
+                "type": "string"
+              },
+              "field_name": {
+                "type": "string"
+              },
+              "colour": {
+                "type": "string",
+                "nullable": true
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "priority": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "internal_name": {
+                "type": "string"
+              },
+              "field_name": {
+                "type": "string"
+              },
+              "colour": {
+                "type": "string",
+                "nullable": true
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "status": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "internal_name": {
+                "type": "string"
+              },
+              "field_name": {
+                "type": "string"
+              },
+              "colour": {
+                "type": "string"
+              }
+            }
+          },
+          "case_type_imported": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "custom_fields": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "estimate": {
+            "type": "string",
+            "nullable": true
+          },
+          "expected_result": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "is_automation": {
+            "type": "boolean"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "type": "string"
+              },
+              "detail": {
+                "type": "string"
+              },
+              "folder": {
+                "type": "string"
+              }
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "history_count": {
+            "type": "integer",
+            "nullable": true
+          },
+          "owner": {
+            "type": "integer",
+            "nullable": true
+          },
+          "preconditions": {
+            "type": "string",
+            "nullable": true
+          },
+          "owner_imported": {
+            "type": "string"
+          },
+          "priority_imported": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "integer"
+          },
+          "status_imported": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "step": {
+                  "type": "string"
+                },
+                "result": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "template": {
+            "type": "string"
+          },
+          "test_case_folder_id": {
+            "type": "integer"
+          },
+          "test_case_steps": {
+            "$schema": "TestCaseStep"
+          },
+          "lcnc_build_map": {
+            "type": "object",
+            "properties": {
+              "resource_path": {
+                "type": "string",
+                "nullable": true
+              },
+              "status": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "automation_status": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "issues": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "comments_count": {
+            "type": "integer"
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "lcnc_build_map": {
+                "type": "object",
+                "properties": {
+                  "resource_path": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "status": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              },
+              "ai_prompt": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "PageInfo": {
+        "type": "object",
+        "description": "Pagination metadata returned with paged API responses.",
+        "required": [
+          "page",
+          "page_size",
+          "count",
+          "prev",
+          "next"
+        ],
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "Current page number."
+          },
+          "page_size": {
+            "type": "integer",
+            "description": "Number of items per page."
+          },
+          "count": {
+            "type": "integer",
+            "description": "Total number of items."
+          },
+          "prev": {
+            "type": "integer",
+            "description": "Previous page number if applicable; null otherwise.",
+            "nullable": true
+          },
+          "next": {
+            "type": "integer",
+            "description": "Next page number if applicable; null otherwise.",
+            "nullable": true
+          }
+        }
+      },
+      "TestCaseListResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "test_cases": {
+            "type": "array",
+            "items": {
+              "$schema": "TestCase"
+            }
+          },
+          "info": {
+            "$schema": "PageInfo"
+          }
+        }
+      },
+      "Folder": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "project_id": {
+            "type": "integer"
+          },
+          "group_id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "is_automation": {
+            "type": "boolean"
+          },
+          "sub_folders_count": {
+            "type": "integer"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "type": "string"
+              }
+            }
+          },
+          "cases_count": {
+            "type": "integer"
+          },
+          "total_cases_count": {
+            "type": "integer"
+          }
+        }
+      },
+      "Configuration": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique identifier for the configuration."
+          },
+          "group_id": {
+            "type": "integer",
+            "description": "ID of the group associated with the configuration."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the configuration."
+          },
+          "record_status": {
+            "type": "string",
+            "description": "Status of the record (e.g., active)."
+          },
+          "is_suggested": {
+            "type": "boolean",
+            "description": "Indicates if the configuration is suggested."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp."
+          }
+        }
+      },
+      "Dataset": {
+        "type": "object",
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "description": "Unique identifier for the dataset."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the dataset."
+          },
+          "variables": {
+            "type": "array",
+            "description": "List of dataset variables/columns.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the variable/column."
+                },
+                "uuid": {
+                  "type": "string",
+                  "description": "Unique identifier for the variable/column."
+                }
+              }
+            }
+          },
+          "rows": {
+            "type": "array",
+            "description": "List of dataset rows.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "row_data": {
+                  "type": "array",
+                  "description": "Array of values for the row.",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "row_number": {
+                  "type": "integer",
+                  "description": "Row number in the dataset."
+                },
+                "uuid": {
+                  "type": "string",
+                  "description": "Unique identifier for the row."
+                }
+              }
+            }
+          },
+          "rows_count": {
+            "type": "integer",
+            "description": "Total number of rows in the dataset."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the dataset was created."
+          },
+          "created_by": {
+            "$schema": "User"
+          }
+        }
+      },
+      "ExploratorySessionUserRef": {
+        "type": "object",
+        "description": "A user reference object returned in exploratory session responses.",
+        "nullable": true,
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "TCM user ID.",
+            "example": 1
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "User email address.",
+            "example": "user@example.com"
+          },
+          "full_name": {
+            "type": "string",
+            "description": "User full name.",
+            "example": "Jane Doe"
+          },
+          "group_id": {
+            "type": "integer",
+            "description": "Group ID the user belongs to.",
+            "example": 10
+          }
+        }
+      },
+      "ExploratorySessionIssue": {
+        "type": "object",
+        "description": "A linked issue / defect associated with an exploratory session or session log.",
+        "required": [
+          "issue_id",
+          "issue_type"
+        ],
+        "properties": {
+          "issue_id": {
+            "type": "string",
+            "description": "Identifier of the issue in the external issue tracker (e.g. Jira key).",
+            "example": "PROJ-123"
+          },
+          "issue_type": {
+            "type": "string",
+            "description": "Type of the issue in the external tracker.",
+            "example": "Bug"
+          }
+        }
+      },
+      "ExploratorySessionTimelineEntry": {
+        "type": "object",
+        "description": "A single timeline event recorded against an exploratory session.",
+        "properties": {
+          "created_by": {
+            "$schema": "ExploratorySessionUserRef"
+          },
+          "action": {
+            "type": "string",
+            "description": "The lifecycle action that was performed.",
+            "example": "created"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp when the action occurred.",
+            "example": "2026-01-16T10:30:00Z"
+          }
+        }
+      },
+      "ExploratorySession": {
+        "type": "object",
+        "description": "An exploratory testing session.",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique identifier for the exploratory session.",
+            "example": 123
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the exploratory session.",
+            "example": "Checkout flow exploration"
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional description of the session.",
+            "example": "Exploring the checkout flow for edge cases.",
+            "nullable": true
+          },
+          "charter": {
+            "type": "string",
+            "description": "Testing charter describing the scope and goals of this session.",
+            "example": "Explore payment gateway error handling",
+            "nullable": true
+          },
+          "session_state": {
+            "type": "string",
+            "description": "Current lifecycle state of the session.",
+            "enum": [
+              "active",
+              "closed"
+            ],
+            "example": "active"
+          },
+          "timebox_duration": {
+            "type": "integer",
+            "description": "Planned duration of the session in minutes.",
+            "example": 60,
+            "nullable": true
+          },
+          "duration": {
+            "type": "integer",
+            "description": "Actual duration tracked during the session in minutes.",
+            "example": 45,
+            "nullable": true
+          },
+          "actual_duration": {
+            "type": "integer",
+            "description": "Final recorded duration of the session in minutes (set on close).",
+            "example": 50,
+            "nullable": true
+          },
+          "session_log_count": {
+            "type": "integer",
+            "description": "Number of logs recorded in this session.",
+            "example": 12
+          },
+          "folder_id": {
+            "type": "integer",
+            "description": "ID of the folder this session belongs to.",
+            "example": 456,
+            "nullable": true
+          },
+          "assignee": {
+            "$schema": "ExploratorySessionUserRef"
+          },
+          "created_by": {
+            "$schema": "ExploratorySessionUserRef"
+          },
+          "closed_by": {
+            "$schema": "ExploratorySessionUserRef"
+          },
+          "tags": {
+            "type": "array",
+            "description": "Tags associated with the session.",
+            "example": [
+              "regression",
+              "payment"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "configurations": {
+            "type": "array",
+            "description": "Configurations associated with the session.",
+            "items": {
+              "type": "object"
+            }
+          },
+          "issues": {
+            "type": "array",
+            "description": "Issues linked to this session.",
+            "items": {
+              "$schema": "ExploratorySessionIssue"
+            }
+          },
+          "timeline": {
+            "type": "array",
+            "description": "Ordered list of lifecycle events for this session.",
+            "items": {
+              "$schema": "ExploratorySessionTimelineEntry"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the session was created.",
+            "example": "2026-01-16T10:30:00Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the session was last updated.",
+            "example": "2026-01-16T11:00:00Z"
+          }
+        }
+      },
+      "ExploratorySessionLog": {
+        "type": "object",
+        "description": "A log entry recorded within an exploratory testing session.",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique identifier for the session log.",
+            "example": 789
+          },
+          "session_id": {
+            "type": "integer",
+            "description": "ID of the exploratory session this log belongs to.",
+            "example": 123
+          },
+          "content": {
+            "type": "string",
+            "description": "Rich-text HTML content of the log entry.",
+            "example": "<p>Found an issue with the payment button on mobile.</p>",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "description": "Test result status for this log entry.",
+            "enum": [
+              "pass",
+              "fail",
+              "bug",
+              "retest",
+              "block",
+              "note"
+            ],
+            "example": "fail",
+            "nullable": true
+          },
+          "elapsed_time": {
+            "type": "integer",
+            "description": "Time elapsed for this step in seconds.",
+            "example": 120,
+            "nullable": true
+          },
+          "created_by": {
+            "$schema": "ExploratorySessionUserRef"
+          },
+          "defects": {
+            "type": "array",
+            "description": "Defects / issues linked to this log entry.",
+            "items": {
+              "$schema": "ExploratorySessionIssue"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the log was created.",
+            "example": "2026-01-16T10:35:00Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the log was last updated.",
+            "example": "2026-01-16T10:40:00Z"
+          }
+        }
+      },
+      "Filter": {
+        "type": "object",
+        "description": "Filter object representing a saved filter view",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique identifier for the filter"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the filter"
+          },
+          "entity_type": {
+            "type": "string",
+            "description": "Entity type the filter applies to",
+            "enum": [
+              "testcase",
+              "testplan",
+              "testrun"
+            ]
+          },
+          "is_project_level": {
+            "type": "boolean",
+            "description": "Whether this filter is available at project level"
+          },
+          "filters": {
+            "type": "object",
+            "description": "Filter criteria object containing the actual filter conditions"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the filter was created"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the filter was last updated"
+          },
+          "owner": {
+            "type": "integer",
+            "description": "User ID of the creator"
+          },
+          "project_id": {
+            "type": "integer",
+            "description": "Project ID this filter belongs to"
+          }
+        }
+      },
+      "ProjectCreateRequest": {
+        "type": "object",
+        "required": [
+          "project"
+        ],
+        "properties": {
+          "project": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ReportType": {
+        "type": "string",
+        "description": "Report type, sent as its DISPLAY NAME (not a machine slug).\n\nSeven types produce data. `Defects Summary` and `Defects Detailed Report` are\naccepted on create/update but have no data branch on the server, so such a report\nalways reads back with `report_data: null` — never offer them as a way to report\non defects (use `Test Run Summary`, whose sections include `issues_by_priority` /\n`issues_by_status`).\n\nPick by what the user asked about:\n  - test cases created / updated / deleted, churn, top creators → `Test Case Activity`\n  - run execution + pass rates                                 → `Test Run Summary`\n  - per-case results within runs                               → `Test Run Detailed Report`\n  - plan-level rollup                                          → `Test Plan Summary`\n  - requirement/issue coverage                                 → `Requirement Traceability Report`\n  - exploratory sessions                                       → `Exploratory Session Summary`\n  - per-user workload                                          → `User Workload Report`\n",
+        "enum": [
+          "Test Run Summary",
+          "Test Run Detailed Report",
+          "Test Plan Summary",
+          "Requirement Traceability Report",
+          "Test Case Activity",
+          "Exploratory Session Summary",
+          "User Workload Report",
+          "Defects Summary",
+          "Defects Detailed Report"
+        ],
+        "example": "Test Run Summary"
+      },
+      "ReportFrequency": {
+        "type": "string",
+        "description": "Scheduling cadence. Send `frequency` and `frequency_details` TOGETHER, or omit\nBOTH — omitting both creates a valid unscheduled, on-demand report.\n\nTwo consequences of omitting them: `mail_to` is only persisted for scheduled\nreports (recipients on an unscheduled report are silently dropped), and\n`next_run_at` stays null.\n\nThere is no `once` value — the server's cadence enum is daily/weekly/monthly only.\n",
+        "enum": [
+          "daily",
+          "weekly",
+          "monthly"
+        ],
+        "example": "weekly"
+      },
+      "ReportTimeframe": {
+        "type": "string",
+        "description": "The window a report covers. Also the value of the `reportTimeRange` query param\non the report-detail read.\n\nThe four relative windows compute a date range from \"now\". `custom` computes it\nfrom `custom_date_range` and **requires** that field — sending `custom` without it\nis an unhandled server error, not a 422.\n\nThe five remaining values carry no dates; they select entities through\n`report_filters` instead:\n  `specific_test_runs`  → report_filters.test_runs\n  `specific_test_plans` → report_filters.test_plans\n  `specific_test_cases` → report_filters.test_cases\n  `specific_sessions`   → report_filters.session_ids\n  `requirements`        → report_filters.requirements\n",
+        "enum": [
+          "last_one_day",
+          "last_one_week",
+          "last_one_month",
+          "last_three_months",
+          "custom",
+          "specific_test_runs",
+          "specific_test_plans",
+          "specific_test_cases",
+          "specific_sessions",
+          "requirements"
+        ],
+        "example": "last_one_week"
+      },
+      "FrequencyDetails": {
+        "type": "object",
+        "description": "Shape depends on `frequency` — the server rejects the wrong shape with\n\"Invalid report frequency\", which names `frequency` even when `frequency` itself\nwas fine and only `day` was missing:\n\n  daily   → { \"time\": \"08:00\" }\n  weekly  → { \"time\": \"08:00\", \"day\": \"monday\" }   day = lowercase day name\n  monthly → { \"time\": \"08:00\", \"day\": 15 }         day = integer 1-28\n\n`time` is 24-hour `HH:MM`, interpreted as UTC.\n",
+        "required": [
+          "time"
+        ],
+        "properties": {
+          "time": {
+            "type": "string",
+            "description": "24-hour HH:MM, UTC.",
+            "example": "08:00"
+          },
+          "day": {
+            "description": "Required for weekly (lowercase day name) and monthly (integer 1-28).\nOmit for daily.\n",
+            "example": "monday"
+          }
+        }
+      },
+      "ReportOwner": {
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "full_name",
+          "group_id",
+          "browserstack_user_id",
+          "onboarded",
+          "reports_and_notification_enabled"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 2
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "example": "fake1@example.com"
+          },
+          "full_name": {
+            "type": "string",
+            "example": "Fake Name"
+          },
+          "group_id": {
+            "type": "integer",
+            "example": 1
+          },
+          "browserstack_user_id": {
+            "type": "integer",
+            "example": 2
+          },
+          "onboarded": {
+            "type": "integer",
+            "example": 1
+          },
+          "reports_and_notification_enabled": {
+            "type": "boolean",
+            "example": true
+          }
+        }
+      },
+      "MailToUser": {
+        "type": "object",
+        "required": [
+          "users",
+          "external_mails"
+        ],
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$schema": "ReportOwner"
+            }
+          },
+          "external_mails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ReportDetail": {
+        "type": "object",
+        "required": [
+          "id",
+          "report_type",
+          "created_at",
+          "description",
+          "title",
+          "frequency",
+          "identifier",
+          "next_run_at",
+          "report_timeframe",
+          "group_id",
+          "frequency_details",
+          "project_id",
+          "report_creation_mode",
+          "owner",
+          "mail_to"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 3
+          },
+          "report_type": {
+            "$schema": "ReportType"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-05-12T12:52:17.658Z"
+          },
+          "description": {
+            "type": "string",
+            "example": ""
+          },
+          "title": {
+            "type": "string",
+            "example": "Test Run Summary"
+          },
+          "frequency": {
+            "type": "object"
+          },
+          "identifier": {
+            "type": "string",
+            "example": "SC-3"
+          },
+          "next_run_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-05-13T05:00:00.000Z",
+            "nullable": true
+          },
+          "report_timeframe": {
+            "$schema": "ReportTimeframe"
+          },
+          "group_id": {
+            "type": "integer",
+            "example": 1
+          },
+          "frequency_details": {
+            "type": "object",
+            "properties": {
+              "time": {
+                "type": "string",
+                "description": "24-hour HH:MM, UTC.",
+                "example": "08:00"
+              },
+              "day": {
+                "description": "Required for weekly (lowercase day name) and monthly (integer 1-28).\nOmit for daily.\n",
+                "example": "monday"
+              }
+            },
+            "required": [
+              "time"
+            ]
+          },
+          "project_id": {
+            "type": "integer",
+            "example": 10000
+          },
+          "report_creation_mode": {
+            "type": "string",
+            "enum": [
+              "custom_report",
+              "system_generated"
+            ],
+            "example": "custom_report"
+          },
+          "custom_date_range": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "owner": {
+            "$schema": "ReportOwner"
+          },
+          "mail_to": {
+            "$schema": "MailToUser"
+          }
+        }
+      },
+      "CreateReportResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "data",
+          "project"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "data": {
+            "$schema": "ReportDetail"
+          },
+          "project": {
+            "$schema": "Project"
+          }
+        }
+      },
+      "FolderHierarchy": {
+        "type": "object",
+        "description": "Folder hierarchy mapping. Each key is a folder ID (as a string), and the value is an array of ancestor folder objects ordered from the folder itself up to the root.\n",
+        "example": {
+          "9": [
+            {
+              "id": 9,
+              "name": "1",
+              "parent_id": null
+            }
+          ],
+          "10": [
+            {
+              "id": 10,
+              "name": "1.2",
+              "parent_id": 9
+            },
+            {
+              "id": 9,
+              "name": "1",
+              "parent_id": null
+            }
+          ],
+          "11": [
+            {
+              "id": 11,
+              "name": "1.2.2",
+              "parent_id": 10
+            },
+            {
+              "id": 10,
+              "name": "1.2",
+              "parent_id": 9
+            },
+            {
+              "id": 9,
+              "name": "1",
+              "parent_id": null
+            }
+          ]
+        }
+      },
+      "SharedStepBase": {
+        "type": "object",
+        "required": [
+          "title",
+          "id",
+          "created_by",
+          "updated_by"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "created_by": {
+            "type": "object",
+            "required": [
+              "id",
+              "full_name"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "full_name": {
+                "type": "string"
+              }
+            }
+          },
+          "updated_by": {
+            "type": "object",
+            "required": [
+              "id",
+              "full_name"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "full_name": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "SharedStepDetail": {
+        "type": "object",
+        "required": [
+          "id",
+          "step",
+          "result",
+          "order"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "step": {
+            "type": "string",
+            "description": "HTML formatted step content"
+          },
+          "result": {
+            "type": "string",
+            "description": "HTML formatted expected result content"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "test_data": {
+            "type": "string",
+            "description": "Optional test data for the step"
+          }
+        }
+      },
+      "ResultStatus": {
+        "type": "object",
+        "required": [
+          "id",
+          "field_value",
+          "internal_name",
+          "field_name",
+          "colour"
+        ],
+        "properties": {
+          "entity_type": {
+            "type": "string",
+            "example": "TestCase"
+          },
+          "id": {
+            "type": "integer",
+            "example": 22
+          },
+          "field_value": {
+            "type": "string",
+            "example": "Failed"
+          },
+          "internal_name": {
+            "type": "string",
+            "example": "failed"
+          },
+          "field_name": {
+            "type": "string",
+            "example": "status"
+          },
+          "colour": {
+            "type": "string",
+            "example": "#F87171"
+          }
+        }
+      },
+      "Attachment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "product_id": {
+            "type": "integer"
+          },
+          "byte_size": {
+            "type": "integer"
+          },
+          "checksum": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "download_url": {
+            "type": "string"
+          }
+        }
+      },
+      "TestResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "author": {
+            "$schema": "User"
+          },
+          "backtrace": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-05-25T20:02:05.000Z"
+          },
+          "description": {
+            "type": "string"
+          },
+          "error_description": {
+            "type": "string",
+            "nullable": true
+          },
+          "expanded": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "failure_type": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "finished_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "log_type": {
+            "type": "string",
+            "nullable": true
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "example": "passed"
+          },
+          "result_status": {
+            "$schema": "ResultStatus"
+          },
+          "configuration_id": {
+            "type": "integer",
+            "description": "ID of the configuration this test result is associated with",
+            "example": 16,
+            "nullable": true
+          },
+          "time_elapsed": {
+            "type": "string",
+            "nullable": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "content_type": {
+                  "type": "string"
+                },
+                "key": {
+                  "type": "string"
+                },
+                "product_id": {
+                  "type": "integer"
+                },
+                "byte_size": {
+                  "type": "integer"
+                },
+                "checksum": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "download_url": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "created_by_imported": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "issues": {
+            "type": "array",
+            "example": [],
+            "items": {
+              "type": "object"
+            }
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "type": "string",
+                "example": "/api/v1/projects/10000/test-results/1473"
+              },
+              "custom_fields": {
+                "type": "string",
+                "example": "/api/v1/projects/10000/test-results/1473/custom-fields"
+              }
+            }
+          },
+          "custom_fields": {
+            "type": "object"
+          },
+          "test_run_step_result": {
+            "type": "object",
+            "nullable": true
+          }
+        }
+      },
+      "Report": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Report ID"
+          },
+          "report_type": {
+            "$schema": "ReportType"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp indicating when the scheduled report was created"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the scheduled report"
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the scheduled report"
+          },
+          "frequency": {
+            "type": "object"
+          },
+          "identifier": {
+            "type": "string",
+            "description": "The report's SC-NNN identifier"
+          },
+          "next_run_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Next scheduled iteration, or null when the report is not scheduled",
+            "nullable": true
+          },
+          "report_timeframe": {
+            "$schema": "ReportTimeframe"
+          },
+          "group_id": {
+            "type": "integer"
+          },
+          "frequency_details": {
+            "type": "object",
+            "properties": {
+              "time": {
+                "type": "string",
+                "description": "24-hour HH:MM, UTC.",
+                "example": "08:00"
+              },
+              "day": {
+                "description": "Required for weekly (lowercase day name) and monthly (integer 1-28).\nOmit for daily.\n",
+                "example": "monday"
+              }
+            },
+            "required": [
+              "time"
+            ]
+          },
+          "project_id": {
+            "type": "integer"
+          },
+          "report_creation_mode": {
+            "type": "string",
+            "enum": [
+              "custom_report",
+              "system_generated"
+            ]
+          },
+          "custom_date_range": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "Id of the report owner"
+              },
+              "email": {
+                "type": "string",
+                "description": "Email to which the report is to be sent"
+              },
+              "full_name": {
+                "type": "string",
+                "description": "Name of the owner"
+              },
+              "group_id": {
+                "type": "integer"
+              },
+              "browserstack_user_id": {
+                "type": "integer"
+              },
+              "onboarded": {
+                "type": "integer"
+              },
+              "reports_and_notification_enabled": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "AttachmentResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 1
+          },
+          "filename": {
+            "type": "string",
+            "example": "document1.pdf"
+          },
+          "content_type": {
+            "type": "string",
+            "example": "application/pdf"
+          },
+          "byte_size": {
+            "type": "integer",
+            "example": 102400
+          }
+        }
+      },
+      "configuration": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique identifier for the configuration."
+          },
+          "group_id": {
+            "type": "integer",
+            "description": "ID of the group associated with the configuration."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the configuration."
+          },
+          "record_status": {
+            "type": "string",
+            "description": "Status of the record (e.g., active)."
+          },
+          "is_suggested": {
+            "type": "boolean",
+            "description": "Indicates if the configuration is suggested."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp."
+          }
+        }
+      },
+      "ConfigurationListResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Indicates if the operation was successful."
+          },
+          "configurations": {
+            "type": "array",
+            "description": "List of configuration objects.",
+            "items": {
+              "$schema": "configuration"
+            }
+          },
+          "info": {
+            "$schema": "PageInfo"
+          }
+        }
+      },
+      "DatasetVariable": {
+        "type": "object",
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "description": "Unique identifier for the dataset column/variable."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the column/variable."
+          },
+          "dataset": {
+            "type": "object",
+            "description": "Dataset information that this column belongs to.",
+            "properties": {
+              "uuid": {
+                "type": "string",
+                "description": "Unique identifier for the dataset."
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of the dataset."
+              },
+              "count_rows": {
+                "type": "integer",
+                "description": "Number of rows in the dataset."
+              }
+            }
+          }
+        }
+      },
+      "DatasetVariablesResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Indicates if the request was successful."
+          },
+          "variables": {
+            "type": "array",
+            "description": "List of dataset columns/variables.",
+            "items": {
+              "$schema": "DatasetVariable"
+            }
+          },
+          "info": {
+            "$schema": "PageInfo"
+          }
+        }
+      },
+      "MyselfUser": {
+        "type": "object",
+        "required": [
+          "id",
+          "full_name",
+          "reports_and_notification_enabled"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "User ID"
+          },
+          "full_name": {
+            "type": "string",
+            "description": "Full name of the current user"
+          },
+          "email": {
+            "type": "string",
+            "description": "Email address of the current user"
+          },
+          "reports_and_notification_enabled": {
+            "type": "boolean",
+            "description": "Whether reports and notifications are enabled for the user"
+          }
+        }
+      },
+      "UsersV2Response": {
+        "type": "object",
+        "required": [
+          "success",
+          "users",
+          "myself",
+          "info"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$schema": "User"
+            }
+          },
+          "myself": {
+            "$schema": "MyselfUser"
+          },
+          "info": {
+            "$schema": "PageInfo"
+          }
+        }
+      },
+      "V1ProjectDetail": {
+        "type": "object",
+        "description": "v1 project-detail envelope (GET /api/v1/projects/{project_id}, by INTEGER id). The translation output is data.project.identifier (the PR-NNN form), alongside data.project.id (the integer id you queried by).\n",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "success": {
+                "type": "boolean"
+              },
+              "project": {
+                "type": "object",
+                "properties": {
+                  "identifier": {
+                    "type": "string",
+                    "description": "PR-NNN identifier — the v2 {project_id}. (Integer -> PR-NNN translation output.)",
+                    "example": "PR-1"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "description": "Integer project id — the value passed in the path. Same as thProjectId.",
+                    "example": 11046
+                  },
+                  "thProjectId": {
+                    "type": "integer",
+                    "example": 11046
+                  },
+                  "name": {
+                    "type": "string",
+                    "example": "Demo Project"
+                  },
+                  "description": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "user_role": {
+                    "type": "string",
+                    "example": "Admin"
+                  },
+                  "permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "test_cases_count": {
+                    "type": "integer",
+                    "nullable": true
+                  },
+                  "test_runs_count": {
+                    "type": "integer",
+                    "nullable": true
+                  },
+                  "test_plans_count": {
+                    "type": "integer",
+                    "nullable": true
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "starred": {
+                    "type": "boolean"
+                  },
+                  "jira_mapped": {
+                    "type": "boolean"
+                  },
+                  "links": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ProjectMinifyResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "projects"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "projects": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "thProjectId": {
+                  "type": "integer"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "import_id": {
+                  "type": "integer"
+                },
+                "normalisedName": {
+                  "type": "string"
+                },
+                "starred": {
+                  "type": "boolean"
+                },
+                "permissions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ProjectsPaginatedResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "projects": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "thProjectId": {
+                  "type": "integer"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "import_id": {
+                  "type": "integer"
+                },
+                "normalisedName": {
+                  "type": "string"
+                },
+                "starred": {
+                  "type": "boolean"
+                },
+                "permissions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "info": {
+            "$schema": "PageInfo"
+          }
+        },
+        "required": [
+          "info",
+          "projects",
+          "success"
+        ]
+      },
+      "ReportFiltersDetail": {
+        "type": "object",
+        "required": [
+          "custom_fields",
+          "test_run_ids",
+          "first_test_run"
+        ],
+        "properties": {
+          "custom_fields": {
+            "type": "object"
+          },
+          "test_run_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "first_test_run": {
+            "type": "object",
+            "required": [
+              "id",
+              "name",
+              "created_at",
+              "identifier",
+              "is_automation",
+              "run_state",
+              "updated_at",
+              "project_id",
+              "user_id",
+              "group_id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string",
+                "nullable": true
+              },
+              "owner": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "environment": {
+                "type": "string",
+                "nullable": true
+              },
+              "identifier": {
+                "type": "string"
+              },
+              "is_automation": {
+                "type": "boolean"
+              },
+              "run_state": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "project_id": {
+                "type": "integer"
+              },
+              "user_id": {
+                "type": "integer"
+              },
+              "group_id": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "DynamicFilters": {
+        "type": "object",
+        "properties": {
+          "test_run": {
+            "type": "object",
+            "required": [
+              "created_at",
+              "status",
+              "owner",
+              "automation_status",
+              "type"
+            ],
+            "properties": {
+              "created_at": {
+                "type": "string"
+              },
+              "status": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              },
+              "owner": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              },
+              "automation_status": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ReportData": {
+        "type": "object",
+        "required": [
+          "test_run_data",
+          "issues_data",
+          "test_run_status",
+          "test_cases_status",
+          "user_result_stats",
+          "issues_by_status",
+          "issues_by_priority"
+        ],
+        "properties": {
+          "test_run_data": {
+            "type": "object",
+            "required": [
+              "active",
+              "closed",
+              "test_cases",
+              "test_results"
+            ],
+            "properties": {
+              "active": {
+                "type": "integer"
+              },
+              "closed": {
+                "type": "integer"
+              },
+              "test_cases": {
+                "type": "integer"
+              },
+              "test_results": {
+                "type": "integer"
+              }
+            }
+          },
+          "issues_data": {
+            "type": "object",
+            "required": [
+              "total",
+              "linked_with_test_runs",
+              "linked_with_test_results"
+            ],
+            "properties": {
+              "total": {
+                "type": "integer"
+              },
+              "linked_with_test_runs": {
+                "type": "integer"
+              },
+              "linked_with_test_results": {
+                "type": "integer"
+              }
+            }
+          },
+          "test_run_status": {
+            "type": "object"
+          },
+          "test_cases_status": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "count",
+                "result_status"
+              ],
+              "properties": {
+                "count": {
+                  "type": "integer"
+                },
+                "result_status": {
+                  "$schema": "ResultStatus"
+                }
+              }
+            }
+          },
+          "user_result_stats": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "user_id",
+                "test_results",
+                "user_name"
+              ],
+              "properties": {
+                "user_id": {
+                  "type": "integer"
+                },
+                "test_results": {
+                  "type": "integer"
+                },
+                "user_name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "issues_by_status": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "issues_by_priority": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "ReportProjectDetail": {
+        "type": "object",
+        "required": [
+          "id",
+          "group_id",
+          "user_id",
+          "name",
+          "slug",
+          "description",
+          "identifier",
+          "is_demo",
+          "publicly_readable",
+          "created_at",
+          "source",
+          "archived",
+          "team_id",
+          "default_team_id"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 10000
+          },
+          "group_id": {
+            "type": "integer",
+            "example": 1
+          },
+          "user_id": {
+            "type": "integer",
+            "example": 2
+          },
+          "name": {
+            "type": "string",
+            "example": "Demo Project"
+          },
+          "slug": {
+            "type": "string",
+            "example": "Demo-Project-8e37e463"
+          },
+          "description": {
+            "type": "string",
+            "example": "This project contains test cases and test runs for the demo project"
+          },
+          "identifier": {
+            "type": "string",
+            "example": "PR-3"
+          },
+          "is_demo": {
+            "type": "boolean",
+            "example": false
+          },
+          "publicly_readable": {
+            "type": "boolean",
+            "example": false
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2024-06-28T00:00:00.000Z"
+          },
+          "source": {
+            "type": "string",
+            "example": "TCM"
+          },
+          "archived": {
+            "type": "integer",
+            "example": 0
+          },
+          "team_id": {
+            "type": "integer",
+            "example": 1
+          },
+          "default_team_id": {
+            "type": "integer",
+            "example": null,
+            "nullable": true
+          }
+        }
+      },
+      "SelectionData": {
+        "type": "object",
+        "description": "A folder-keyed test-case selection: which cases, grouped by the folder they live in.\nAll three keys are required. Widen with `select_all` (whole project) or a folder's\n`test_case_select_all` (whole folder), then subtract with `deselected_test_cases`;\notherwise the cases are listed explicitly in `selected_test_cases`.\n",
+        "required": [
+          "select_all",
+          "folders",
+          "unique_test_case_count"
+        ],
+        "properties": {
+          "select_all": {
+            "type": "boolean",
+            "description": "Select every case in the project.",
+            "example": false
+          },
+          "folders": {
+            "type": "object",
+            "description": "Map of folder id (as a STRING key) to that folder's selection."
+          },
+          "unique_test_case_count": {
+            "type": "integer",
+            "description": "Number of distinct cases the selection resolves to.",
+            "example": 3
+          }
+        }
+      },
+      "V1TestCaseDetail": {
+        "type": "object",
+        "description": "v1 test-case detail (GET /api/v1/projects/{project_id}/folder/{folder_id}/test-cases/{test_case_id}, by INTEGER ids). Translation output: data.test_case.identifier (the TC-NNN form).\n",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "success": {
+                "type": "boolean"
+              },
+              "test_case": {
+                "type": "object",
+                "properties": {
+                  "identifier": {
+                    "type": "string",
+                    "description": "TC-NNN identifier — the v2 test-case id (read via ?id=TC-NNN). (Integer -> TC-NNN translation output.)",
+                    "example": "TC-333"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "description": "Integer test-case id — the value passed in the path.",
+                    "example": 333
+                  },
+                  "title": {
+                    "type": "string",
+                    "example": "Login with valid credentials"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "TestCaseTrend": {
+        "type": "object",
+        "required": [
+          "graphData",
+          "field",
+          "value"
+        ],
+        "properties": {
+          "graphData": {
+            "type": "object",
+            "properties": {
+              "Jun": {
+                "type": "integer"
+              },
+              "Jul": {
+                "type": "integer"
+              },
+              "Aug": {
+                "type": "integer"
+              },
+              "Sep": {
+                "type": "integer"
+              },
+              "Oct": {
+                "type": "integer"
+              },
+              "Nov": {
+                "type": "integer"
+              },
+              "Dec": {
+                "type": "integer"
+              },
+              "Jan": {
+                "type": "integer"
+              },
+              "Feb": {
+                "type": "integer"
+              },
+              "Mar": {
+                "type": "integer"
+              },
+              "Apr": {
+                "type": "integer"
+              },
+              "May": {
+                "type": "integer"
+              }
+            }
+          },
+          "field": {
+            "type": "string"
+          },
+          "value": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "History": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "history record ID"
+          },
+          "entity_id": {
+            "type": "integer",
+            "description": "test case ID this history belongs to"
+          },
+          "entity_type": {
+            "type": "string",
+            "example": "TestCase"
+          },
+          "version_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "source": {
+            "type": "string",
+            "description": "Source of the change (e.g., \"update\", \"create\")"
+          },
+          "modified_fields": {
+            "type": "array",
+            "description": "List of fields that were modified in this version",
+            "items": {
+              "type": "string"
+            }
+          },
+          "project_id": {
+            "type": "integer"
+          },
+          "group_id": {
+            "type": "integer"
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "user_id": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modified": {
+            "type": "object",
+            "description": "Details of what was modified (field changes)",
+            "example": {
+              "template": {
+                "old": "Test Case Steps",
+                "new": "Test Case BDD"
+              }
+            }
+          },
+          "version_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "user": {
+            "$schema": "User"
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": {
+                "type": "string",
+                "description": "API endpoint to retrieve this specific history record",
+                "example": "/api/v1/projects/2022091/test-cases/36347792/histories/17604265"
+              }
+            }
+          }
+        }
+      },
+      "HistoryListResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "histories": {
+            "type": "array",
+            "description": "List of history records for the test case",
+            "items": {
+              "$schema": "History"
+            }
+          },
+          "info": {
+            "$schema": "PageInfo"
+          },
+          "plan_restriction": {
+            "type": "boolean"
+          }
+        }
+      },
+      "TestCaseDiffStep": {
+        "type": "object",
+        "required": [
+          "id",
+          "step",
+          "order",
+          "result"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "step": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "result": {
+            "type": "string"
+          },
+          "shared_step_id": {
+            "type": "integer",
+            "nullable": true
+          }
+        }
+      },
+      "TestCaseConsolidatedResultFolders": {
+        "type": "object"
+      },
+      "TestCaseConsolidatedListResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "test_cases": {
+            "type": "array",
+            "items": {
+              "$schema": "TestCase"
+            }
+          },
+          "info": {
+            "$schema": "PageInfo"
+          },
+          "folders": {
+            "$schema": "TestCaseConsolidatedResultFolders"
+          }
+        }
+      },
+      "V1TestPlanDetail": {
+        "type": "object",
+        "description": "v1 test-plan detail (GET /api/v1/projects/{project_id}/test-plans/{test_plan_id}, by INTEGER ids). NOTE: there is NO `data` wrapper — the plan sits at the top level under `test_plan`. Translation output: test_plan.identifier (the TP-NNN form).\n",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "test_plan": {
+            "type": "object",
+            "properties": {
+              "identifier": {
+                "type": "string",
+                "description": "TP-NNN identifier — the v2 {test_plan_id}. (Integer -> TP-NNN translation output.)",
+                "example": "TP-12345"
+              },
+              "name": {
+                "type": "string",
+                "example": "Release 2.0 plan"
+              }
+            }
+          }
+        }
+      },
+      "ResultCustomField": {
+        "type": "object",
+        "required": [
+          "id",
+          "field_type",
+          "field_name",
+          "entity_type",
+          "field_user_name",
+          "optional",
+          "is_bulk_editable",
+          "is_filterable",
+          "links",
+          "is_required"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "field_type": {
+            "type": "string",
+            "enum": [
+              "field_string",
+              "field_text",
+              "field_user",
+              "field_dropdown",
+              "field_multi_dropdown",
+              "field_url",
+              "field_boolean",
+              "field_int",
+              "field_date",
+              "field_rte"
+            ]
+          },
+          "field_name": {
+            "type": "string"
+          },
+          "entity_type": {
+            "type": "string",
+            "enum": [
+              "TestCase",
+              "TestResult",
+              "TestExecution",
+              "Build"
+            ]
+          },
+          "field_user_name": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "boolean"
+          },
+          "is_bulk_editable": {
+            "type": "boolean"
+          },
+          "is_filterable": {
+            "type": "boolean"
+          },
+          "links": {
+            "type": "object",
+            "required": [
+              "self"
+            ],
+            "properties": {
+              "self": {
+                "type": "string"
+              }
+            }
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "is_required": {
+            "type": "boolean"
+          },
+          "default_value": {
+            "type": "object"
+          },
+          "option_values": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "field_values": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "sort_options": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "TestResultCustomFieldsResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "data",
+          "info"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$schema": "ResultCustomField"
+            }
+          },
+          "info": {
+            "$schema": "PageInfo"
+          }
+        }
+      },
+      "V1TestRunDetail": {
+        "type": "object",
+        "description": "v1 test-run detail (GET /api/v1/projects/{project_id}/test-runs/{test_run_id}, by INTEGER ids). Translation output: data.test_run.identifier (the TR-NNN form). The integer run id is surfaced as data.test_run.uuid.\n",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "success": {
+                "type": "boolean"
+              },
+              "test_run": {
+                "type": "object",
+                "properties": {
+                  "identifier": {
+                    "type": "string",
+                    "description": "TR-NNN identifier — the v2 {test_run_id}. (Integer -> TR-NNN translation output.)",
+                    "example": "TR-17"
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "Also the TR-NNN identifier (string form).",
+                    "example": "TR-17"
+                  },
+                  "uuid": {
+                    "type": "integer",
+                    "description": "Integer test-run id — the value passed in the path.",
+                    "example": 17
+                  },
+                  "name": {
+                    "type": "string",
+                    "example": "Regression - Sprint 12"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "TestResultStatusValue": {
+        "type": "object",
+        "required": [
+          "internal_name",
+          "is_default",
+          "colour",
+          "value",
+          "name"
+        ],
+        "properties": {
+          "internal_name": {
+            "type": "string",
+            "description": "Internal system name for the status"
+          },
+          "is_default": {
+            "type": "integer",
+            "description": "Whether this is the default status (1 or 0)",
+            "enum": [
+              0,
+              1
+            ]
+          },
+          "colour": {
+            "type": "string",
+            "description": "Hex color code for the status"
+          },
+          "value": {
+            "type": "integer",
+            "description": "Numeric value identifier for the status"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name of the status"
+          }
+        }
+      },
+      "TestResultStatusField": {
+        "type": "object",
+        "required": [
+          "values",
+          "total_count",
+          "links"
+        ],
+        "properties": {
+          "values": {
+            "type": "array",
+            "description": "Array of test result status values",
+            "items": {
+              "$schema": "TestResultStatusValue"
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "Total number of test result status values"
+          },
+          "links": {
+            "type": "object",
+            "description": "Related API links",
+            "required": [
+              "self"
+            ],
+            "properties": {
+              "self": {
+                "type": "string",
+                "description": "Self-referencing API endpoint"
+              }
+            }
+          }
+        }
+      },
+      "CustomField": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the custom field"
+          },
+          "field_type": {
+            "type": "string",
+            "description": "Type of the custom field",
+            "enum": [
+              "string",
+              "text",
+              "user",
+              "dropdown",
+              "multi_dropdown",
+              "url",
+              "boolean",
+              "int",
+              "date"
+            ]
+          },
+          "field_name": {
+            "type": "string",
+            "description": "Name of the custom field"
+          },
+          "is_required": {
+            "type": "boolean",
+            "description": "Whether the custom field is required"
+          },
+          "place_holder_text": {
+            "type": "string",
+            "description": "Placeholder text for the custom field",
+            "nullable": true
+          },
+          "default_value": {
+            "type": "string",
+            "description": "Default value for the custom field",
+            "nullable": true
+          },
+          "entity_type": {
+            "type": "string",
+            "description": "Type of entity this field is for",
+            "example": "TestCase"
+          },
+          "options": {
+            "type": "array",
+            "description": "Options for dropdown or multi-dropdown fields",
+            "items": {
+              "type": "object",
+              "properties": {
+                "option_value": {
+                  "type": "string"
+                },
+                "is_default": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "applies_to_all_projects": {
+            "type": "boolean",
+            "description": "Whether the custom field applies to all projects"
+          },
+          "assigned_projects": {
+            "type": "array",
+            "description": "List of project identifiers this field is assigned to",
+            "items": {
+              "type": "string"
+            }
+          },
+          "link_to_future_projects": {
+            "type": "boolean",
+            "description": "Whether to link this field to future projects"
+          }
+        }
+      },
+      "TestRunFormFieldsResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "default_fields"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "default_fields": {
+            "type": "object",
+            "description": "Default field values for test results. Only 'status' field is included by default.",
+            "properties": {
+              "status": {
+                "$schema": "TestResultStatusField"
+              }
+            }
+          },
+          "custom_fields": {
+            "type": "array",
+            "description": "Custom fields array. Only present when 'all' parameter is true.",
+            "items": {
+              "$schema": "CustomField"
+            }
+          }
+        }
+      },
+      "DatasetMini": {
+        "type": "object",
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "description": "Unique identifier for the dataset."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the dataset."
+          },
+          "rows_count": {
+            "type": "integer",
+            "description": "Total number of rows in the dataset."
+          },
+          "test_cases_count": {
+            "type": "integer",
+            "description": "Number of test cases using this dataset."
+          },
+          "created_by": {
+            "$schema": "User"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the dataset was created."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the dataset was last updated."
+          }
+        }
+      },
+      "DatasetsListResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Indicates if the request was successful."
+          },
+          "datasets": {
+            "type": "array",
+            "description": "List of datasets.",
+            "items": {
+              "$schema": "DatasetMini"
+            }
+          },
+          "info": {
+            "$schema": "PageInfo"
+          }
+        }
+      },
+      "V1DuplicatesListResponse": {
+        "type": "object",
+        "description": "Suggested-duplicate list. NOTE this exact shape with an empty `duplicates` is also what\nthe server returns when the group lacks the dedupe feature flag, so an empty list is not\nevidence that the project has no duplicates — check .../ai-duplicates/status.\n",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "duplicates": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "info": {
+            "type": "object",
+            "properties": {
+              "count": {
+                "type": "integer"
+              },
+              "total_pages": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "ExploratorySessionLogListResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "session_logs": {
+            "type": "array",
+            "items": {
+              "$schema": "ExploratorySessionLog"
+            }
+          },
+          "info": {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "example": 1
+              },
+              "per_page": {
+                "type": "integer",
+                "example": 50
+              },
+              "total_count": {
+                "type": "integer",
+                "example": 24
+              },
+              "total_pages": {
+                "type": "integer",
+                "example": 1
+              }
+            }
+          }
+        }
+      },
+      "ExploratorySessionListResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "exploratory_sessions": {
+            "type": "array",
+            "items": {
+              "$schema": "ExploratorySession"
+            }
+          },
+          "info": {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "example": 1
+              },
+              "per_page": {
+                "type": "integer",
+                "example": 30
+              },
+              "total_count": {
+                "type": "integer",
+                "example": 150
+              },
+              "total_pages": {
+                "type": "integer",
+                "example": 5
+              }
+            }
+          },
+          "count": {
+            "type": "integer",
+            "description": "Total number of sessions matching the query.",
+            "example": 150
+          }
+        }
+      },
+      "ProjectsListResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Indicates if the operation was successful.",
+            "example": true
+          },
+          "projects": {
+            "type": "array",
+            "description": "List of project objects.",
+            "items": {
+              "$schema": "Project"
+            }
+          },
+          "info": {
+            "$schema": "PageInfo"
+          }
+        }
+      },
+      "ReportScheduleGetResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "Contains an array of Scheduled reports",
+            "items": {
+              "$schema": "Report"
+            }
+          },
+          "scheduled_report_count": {
+            "type": "integer",
+            "description": "The total number of scheduled reports in the project."
+          },
+          "total_report_count": {
+            "type": "integer",
+            "description": "The total number of reports in the project."
+          },
+          "info": {
+            "$schema": "PageInfo"
+          }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "required": [
+          "name",
+          "created_at"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Tag name",
+            "example": "AI Generated"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the tag was first used",
+            "example": "2024-10-08T09:25:09.000Z"
+          },
+          "usage_count": {
+            "type": "integer",
+            "description": "Number of test cases using this tag (optional)",
+            "example": 42
+          }
+        }
+      },
+      "ProjectUserDetail": {
+        "type": "object",
+        "required": [
+          "id",
+          "full_name",
+          "onboarded",
+          "group_id",
+          "browserstack_user_id",
+          "role",
+          "has_access",
+          "permissions"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "User ID",
+            "example": 240620
+          },
+          "full_name": {
+            "type": "string",
+            "description": "User's full name",
+            "example": "Jasbir Singh"
+          },
+          "onboarded": {
+            "type": "integer",
+            "description": "Onboarding status (1 = completed, 0 = pending)",
+            "enum": [
+              0,
+              1
+            ],
+            "example": 1
+          },
+          "group_id": {
+            "type": "integer",
+            "description": "Group this user belongs to",
+            "example": 1
+          },
+          "browserstack_user_id": {
+            "type": "integer",
+            "description": "BrowserStack user identifier",
+            "example": 10328238
+          },
+          "role": {
+            "type": "string",
+            "description": "User role in the system",
+            "enum": [
+              "admin",
+              "user",
+              "viewer"
+            ],
+            "example": "user"
+          },
+          "has_access": {
+            "type": "boolean",
+            "description": "Whether user has access to the project",
+            "example": true
+          },
+          "permissions": {
+            "type": "array",
+            "description": "List of permissions granted to user",
+            "example": [
+              "tc_write",
+              "project_write",
+              "test_run_execute"
+            ],
+            "items": {
+              "type": "string",
+              "enum": [
+                "tc_write",
+                "tc_delete",
+                "tc_archive_test_cases",
+                "project_write",
+                "test_plan_write",
+                "test_plan_delete",
+                "test_run_write",
+                "test_run_delete",
+                "test_run_execute"
+              ]
+            }
+          },
+          "is_delighted_visible": {
+            "type": "boolean",
+            "description": "Whether Delighted feedback widget is visible",
+            "example": false
+          },
+          "is_product_intro_visible": {
+            "type": "boolean",
+            "description": "Whether product introduction is visible",
+            "example": true
+          },
+          "is_onboarding_project_header_visible": {
+            "type": "boolean",
+            "description": "Whether onboarding header is visible",
+            "example": true
+          },
+          "is_lcnc_explore_dismissed": {
+            "type": "boolean",
+            "description": "Whether low-code/no-code explore banner is dismissed",
+            "example": false
+          },
+          "reports_and_notification_enabled": {
+            "type": "boolean",
+            "description": "Whether reports and notifications are enabled",
+            "example": true
+          },
+          "customisable_dashboard_accessible": {
+            "type": "boolean",
+            "description": "Whether customizable dashboard is accessible",
+            "example": true
+          },
+          "webhook_accessible": {
+            "type": "boolean",
+            "description": "Whether webhooks are accessible",
+            "example": true
+          },
+          "is_build_listing_enabled": {
+            "type": "boolean",
+            "description": "Whether build listing feature is enabled",
+            "example": true
+          },
+          "productRole": {
+            "type": "string",
+            "description": "Product-level role",
+            "example": "Product User"
+          },
+          "is_new_project_settings_visible": {
+            "type": "boolean",
+            "description": "Whether new project settings UI is visible",
+            "example": true
+          },
+          "is_jira_app_project_panel_visible": {
+            "type": "boolean",
+            "description": "Whether Jira app project panel is visible",
+            "example": false
+          }
+        }
+      },
+      "ReportUpdateResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "report_data",
+          "report_filters",
+          "dynamic_filters"
+        ],
+        "properties": {
+          "data": {
+            "$schema": "ReportDetail"
+          },
+          "report_data": {
+            "$schema": "ReportData"
+          },
+          "report_filters": {
+            "$schema": "ReportFiltersDetail"
+          },
+          "dynamic_filters": {
+            "$schema": "DynamicFilters"
+          }
+        }
+      },
+      "GenericAttachment": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "url",
+          "download_url",
+          "content_type",
+          "size"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Attachment ID",
+            "example": 10288829
+          },
+          "name": {
+            "type": "string",
+            "description": "Original filename",
+            "example": "Screenshot 2025-12-12 at 11.56.57 AM.png"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Pre-signed S3 URL for viewing (inline, ~26 min expiry)",
+            "example": "https://example.com/media/genric/1/2921471/86de8094..."
+          },
+          "download_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Pre-signed S3 URL for downloading (attachment, ~26 min expiry)",
+            "example": "https://example.com/media/genric/1/2921471/86de8094..."
+          },
+          "content_type": {
+            "type": "string",
+            "description": "MIME type of the file",
+            "example": "image/png"
+          },
+          "size": {
+            "type": "string",
+            "description": "Human-readable file size",
+            "example": "300 KB"
+          }
+        }
+      }
+    },
+    "responses": {
+      "TestRunWriteResponse": {
+        "description": "Successfully returned the test run after a WRITE (create / edit / assign / close).\nNOTE the envelope key is `data.testrun` with NO underscore on these four operations,\nunlike clone and the plain reads, which use `data.test_run`. Verified live.\n",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "testrun": {
+                  "$schema": "TestRun"
+                },
+                "project": {
+                  "$schema": "Project"
+                }
+              }
+            }
+          }
+        }
+      },
+      "BadRequest": {
+        "description": "Bad request due to invalid parameters.",
+        "schema": {
+          "$schema": "ErrorResponse"
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized access. Authentication is required.",
+        "schema": {
+          "$schema": "ErrorResponse"
+        }
+      },
+      "NotFound": {
+        "description": "The requested resource was not found.",
+        "schema": {
+          "$schema": "ErrorResponse"
+        }
+      },
+      "InternalServerError": {
+        "description": "Internal server error.",
+        "schema": {
+          "$schema": "ErrorResponse"
+        }
+      },
+      "BulkArchiveResponse": {
+        "description": "Test cases archived successfully",
+        "schema": {
+          "type": "object",
+          "required": [
+            "success",
+            "folders"
+          ],
+          "properties": {
+            "success": {
+              "type": "boolean"
+            },
+            "folders": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Forbidden access. You don't have permission.",
+        "schema": {
+          "$schema": "ErrorResponse"
+        }
+      },
+      "UnprocessableEntity": {
+        "description": "The request was well-formed but contains semantic errors.",
+        "schema": {
+          "$schema": "ErrorResponse"
+        }
+      },
+      "BulkCopyTestCasesResponse": {
+        "description": "Test cases copied successfully",
+        "schema": {
+          "type": "object",
+          "required": [
+            "success",
+            "test_cases",
+            "info",
+            "cases_count",
+            "source_path_folders",
+            "destination_path_folders"
+          ],
+          "properties": {
+            "success": {
+              "type": "boolean"
+            },
+            "test_cases": {
+              "type": "array",
+              "items": {
+                "$schema": "TestCase"
+              }
+            },
+            "info": {
+              "$schema": "PageInfo"
+            },
+            "cases_count": {
+              "type": "object"
+            },
+            "source_path_folders": {
+              "type": "array",
+              "items": {
+                "$schema": "Folder"
+              }
+            },
+            "destination_path_folders": {
+              "type": "array",
+              "items": {
+                "$schema": "Folder"
+              }
+            }
+          }
+        }
+      },
+      "BulkDeleteTestCasesResponse": {
+        "description": "Response after bulk deleting test cases",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            },
+            "test_cases": {
+              "type": "array",
+              "items": {
+                "$schema": "TestCase"
+              }
+            },
+            "info": {
+              "$schema": "PageInfo"
+            },
+            "cases_count": {
+              "type": "object"
+            },
+            "path_folders": {
+              "type": "array",
+              "items": {
+                "$schema": "Folder"
+              }
+            }
+          }
+        }
+      },
+      "BulkMoveTestCasesResponse": {
+        "description": "Successful response for bulk moving test cases",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            },
+            "folders": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "TestRunResponse": {
+        "description": "Successfully return the test run",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "test_run": {
+                  "$schema": "TestRun"
+                },
+                "project": {
+                  "$schema": "Project"
+                }
+              }
+            }
+          }
+        }
+      },
+      "FolderCopyResponse": {
+        "description": "Folder copy operation initiated successfully",
+        "schema": {
+          "type": "object",
+          "required": [
+            "success",
+            "async",
+            "message"
+          ],
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "example": true
+            },
+            "async": {
+              "type": "boolean",
+              "description": "Whether operation is running asynchronously",
+              "example": true
+            },
+            "unique_id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Tracking ID for async operation (present when async=true)",
+              "example": "6a206593-865c-41ec-9459-d94bce72c1b9"
+            },
+            "message": {
+              "type": "string",
+              "example": "Folder copy operation queued successfully"
+            },
+            "folder_id": {
+              "type": "integer",
+              "description": "New folder ID (present when async=false)",
+              "example": 4
+            }
+          }
+        }
+      },
+      "FilterCreateResponse": {
+        "description": "Successfully created a new filter",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$schema": "Filter"
+            },
+            "success": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "CreateReportResponse": {
+        "description": "Successfully created scheduled report",
+        "schema": {
+          "$schema": "CreateReportResponse"
+        }
+      },
+      "RootFolderDetailsResponse": {
+        "description": "Response containing only root folder details including test case counts, and links.",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "info": {
+              "$schema": "PageInfo"
+            },
+            "folder_hierarchy": {
+              "$schema": "FolderHierarchy"
+            },
+            "folders": {
+              "type": "array",
+              "items": {
+                "$schema": "Folder"
+              }
+            },
+            "self": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "project_id": {
+                  "type": "integer"
+                },
+                "group_id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "is_automation": {
+                  "type": "boolean"
+                },
+                "cases_count": {
+                  "type": "integer"
+                },
+                "total_cases_count": {
+                  "type": "integer"
+                },
+                "sub_folders_count": {
+                  "type": "integer"
+                },
+                "links": {
+                  "type": "object",
+                  "properties": {
+                    "self": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "success": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "SharedStepsPostResponse": {
+        "description": "Response containing details of a shared step.",
+        "schema": {
+          "type": "object",
+          "required": [
+            "data",
+            "success"
+          ],
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "created_by": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "full_name"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "full_name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "updated_by": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "full_name"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "full_name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "test_case_count": {
+                  "type": "integer",
+                  "description": "Number of test cases using this shared step"
+                },
+                "step_count": {
+                  "type": "integer",
+                  "description": "Number of steps in this shared step"
+                },
+                "shared_step_details": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "SharedStepDetail"
+                  }
+                }
+              },
+              "required": [
+                "created_by",
+                "id",
+                "shared_step_details",
+                "step_count",
+                "test_case_count",
+                "title",
+                "updated_by"
+              ]
+            },
+            "success": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "TestResultCreateResponse": {
+        "description": "Successful response for creating a test result",
+        "schema": {
+          "type": "object",
+          "required": [
+            "data"
+          ],
+          "properties": {
+            "data": {
+              "type": "object",
+              "required": [
+                "success",
+                "test-result",
+                "unique_issues"
+              ],
+              "properties": {
+                "success": {
+                  "type": "boolean"
+                },
+                "test-result": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "author": {
+                      "$schema": "User"
+                    },
+                    "backtrace": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "2025-05-25T20:02:05.000Z"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "expanded": {
+                      "type": "string",
+                      "example": null,
+                      "nullable": true
+                    },
+                    "failure_type": {
+                      "type": "string",
+                      "example": null,
+                      "nullable": true
+                    },
+                    "finished_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "log_type": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "started_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "passed"
+                    },
+                    "result_status": {
+                      "$schema": "ResultStatus"
+                    },
+                    "configuration_id": {
+                      "type": "integer",
+                      "description": "ID of the configuration this test result is associated with",
+                      "example": 16,
+                      "nullable": true
+                    },
+                    "time_elapsed": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "attachments": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "content_type": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "product_id": {
+                            "type": "integer"
+                          },
+                          "byte_size": {
+                            "type": "integer"
+                          },
+                          "checksum": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string"
+                          },
+                          "download_url": {
+                            "type": "string"
+                          },
+                          "size": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "created_by_imported": {
+                      "type": "boolean",
+                      "nullable": true
+                    },
+                    "issues": {
+                      "type": "array",
+                      "example": [],
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "links": {
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "example": "/api/v1/projects/10000/test-results/1473"
+                        },
+                        "custom_fields": {
+                          "type": "string",
+                          "example": "/api/v1/projects/10000/test-results/1473/custom-fields"
+                        }
+                      }
+                    },
+                    "custom_fields": {
+                      "type": "object"
+                    },
+                    "test_run_step_result": {
+                      "type": "object",
+                      "nullable": true
+                    }
+                  }
+                },
+                "unique_issues": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "FilterDeleteResponse": {
+        "description": "Successfully deleted the filter",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "DeleteScheduleResponse": {
+        "description": "Successfully deleted scheduled report(s)",
+        "schema": {
+          "type": "object",
+          "required": [
+            "success",
+            "data",
+            "info"
+          ],
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "example": true
+            },
+            "data": {
+              "type": "array",
+              "items": {
+                "$schema": "Report"
+              }
+            },
+            "scheduled_report_count": {
+              "type": "integer",
+              "description": "The total number of scheduled reports in the project."
+            },
+            "total_report_count": {
+              "type": "integer",
+              "description": "The total number of reports in the project."
+            },
+            "info": {
+              "$schema": "PageInfo"
+            }
+          }
+        }
+      },
+      "DownloadReportResponse": {
+        "description": "Successfully initiated report download",
+        "schema": {
+          "type": "object",
+          "required": [
+            "channel",
+            "success"
+          ],
+          "properties": {
+            "channel": {
+              "type": "string",
+              "description": "Unique channel identifier for streaming or polling download status.",
+              "example": "53bd342e-b4d8-4003-bb3d-d448a2e8780d"
+            },
+            "success": {
+              "type": "boolean",
+              "example": true
+            }
+          }
+        }
+      },
+      "DashboardExportInitiatedResponse": {
+        "description": "Dashboard export successfully initiated",
+        "schema": {
+          "type": "object",
+          "required": [
+            "success",
+            "export_id"
+          ],
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "example": true
+            },
+            "export_id": {
+              "type": "integer",
+              "description": "Export record ID for tracking progress",
+              "example": 12345
+            },
+            "message": {
+              "type": "string",
+              "description": "Optional status message",
+              "example": "Export queued successfully"
+            }
+          }
+        }
+      },
+      "ActiveTestRunsInfo": {
+        "description": "Active test run results summary",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "y": {
+                "type": "integer"
+              },
+              "result_status": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "field_value": {
+                    "type": "string"
+                  },
+                  "internal_name": {
+                    "type": "string"
+                  },
+                  "field_name": {
+                    "type": "string"
+                  },
+                  "colour": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "AutomationStats": {
+        "description": "Response containing the automation statistics for the test cases.",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            },
+            "automated_coverage": {
+              "type": "number",
+              "format": "float"
+            },
+            "automated_test_cases": {
+              "type": "integer"
+            },
+            "total_test_cases": {
+              "type": "integer"
+            },
+            "manual_test_cases": {
+              "type": "integer"
+            },
+            "empty_data": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "TestRunsListResponse": {
+        "description": "Successfully retrieved test runs",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "example": true
+            },
+            "test_runs": {
+              "type": "array",
+              "items": {
+                "$schema": "TestRun"
+              }
+            },
+            "info": {
+              "$schema": "PageInfo"
+            },
+            "count": {
+              "type": "object",
+              "properties": {
+                "active": {
+                  "type": "integer",
+                  "example": 5
+                },
+                "closed": {
+                  "type": "integer",
+                  "example": 2
+                }
+              }
+            }
+          }
+        }
+      },
+      "ClosedTestRunsInfo": {
+        "description": "Closed test runs analytics data by month",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "array",
+              "example": [
+                {
+                  "month": "Apr",
+                  "count": 3
+                },
+                {
+                  "month": "May",
+                  "count": 0
+                }
+              ],
+              "items": {
+                "type": "object",
+                "properties": {
+                  "month": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "empty_data": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "ClosedTestRunsSplit": {
+        "description": "Closed test run results split by month and status",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "result_status": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "field_value": {
+                        "type": "string"
+                      },
+                      "internal_name": {
+                        "type": "string"
+                      },
+                      "field_name": {
+                        "type": "string"
+                      },
+                      "colour": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "date_list": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "empty_data": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "FilterDetailResponse": {
+        "description": "Successfully retrieved filter details",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$schema": "Filter"
+            },
+            "success": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "RemoveFolderSummaryResponse": {
+        "description": "A summary of entities that would be deleted when removing a folder",
+        "schema": {
+          "type": "object",
+          "required": [
+            "success",
+            "has_other_product_entity",
+            "deleted_entity_count"
+          ],
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "description": "Indicates if the operation was successful"
+            },
+            "has_other_product_entity": {
+              "type": "boolean",
+              "description": "Indicates if the folder contains entities from other products"
+            },
+            "deleted_entity_count": {
+              "type": "object",
+              "required": [
+                "active_test_case_count",
+                "archived_test_case_count",
+                "sub_folders"
+              ],
+              "properties": {
+                "test_recordings_count": {
+                  "type": "integer",
+                  "description": "Number of test recordings that would be deleted"
+                },
+                "active_test_case_count": {
+                  "type": "integer",
+                  "description": "Number of active test cases that would be deleted"
+                },
+                "archived_test_case_count": {
+                  "type": "integer",
+                  "description": "Number of archived test cases that would be deleted"
+                },
+                "sub_folders": {
+                  "type": "integer",
+                  "description": "Number of sub-folders that would be deleted"
+                }
+              }
+            }
+          }
+        }
+      },
+      "UsersV2Response": {
+        "description": "Successfully retrieved users list",
+        "schema": {
+          "$schema": "UsersV2Response"
+        }
+      },
+      "IssuesCountInfo": {
+        "description": "Response containing the issue count trend for each month.",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "label",
+                  "count"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "empty_data": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "CustomFieldsV2Response": {
+        "description": "Successful response with paginated custom fields list",
+        "schema": {
+          "type": "object",
+          "required": [
+            "success",
+            "custom_fields",
+            "info"
+          ],
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "example": true
+            },
+            "custom_fields": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique identifier for the custom field",
+                    "example": "cf-123"
+                  },
+                  "field_type": {
+                    "type": "string",
+                    "description": "Type of the custom field",
+                    "enum": [
+                      "text",
+                      "textarea",
+                      "dropdown",
+                      "multiselect",
+                      "number",
+                      "date",
+                      "boolean",
+                      "url"
+                    ],
+                    "example": "dropdown"
+                  },
+                  "field_name": {
+                    "type": "string",
+                    "description": "Name of the custom field",
+                    "example": "Priority Level"
+                  },
+                  "entity_type": {
+                    "type": "string",
+                    "description": "Entity type this field belongs to",
+                    "example": "TestCase"
+                  },
+                  "is_required": {
+                    "type": "boolean",
+                    "description": "Whether the field is required",
+                    "example": false
+                  },
+                  "default_value": {
+                    "description": "Default value for the field"
+                  },
+                  "place_holder_text": {
+                    "type": "string",
+                    "description": "Placeholder text for the field",
+                    "example": "Select priority level"
+                  },
+                  "system_name": {
+                    "type": "string",
+                    "description": "System name for the field"
+                  },
+                  "is_bulk_editable": {
+                    "type": "boolean",
+                    "description": "Whether the field can be bulk edited"
+                  },
+                  "is_filterable": {
+                    "type": "boolean",
+                    "description": "Whether the field can be used in filters"
+                  },
+                  "linked_projects_count": {
+                    "type": "integer",
+                    "description": "Number of projects this field is linked to",
+                    "example": 5
+                  },
+                  "group_id": {
+                    "type": "string",
+                    "description": "Group ID this field belongs to"
+                  }
+                }
+              }
+            },
+            "info": {
+              "$schema": "PageInfo"
+            }
+          }
+        }
+      },
+      "ProjectsPaginatedResponse": {
+        "description": "Successfully retrieved paginated projects",
+        "schema": {
+          "$schema": "ProjectsPaginatedResponse"
+        }
+      },
+      "ProjectMinifyResponse": {
+        "description": "Successfully retrieved minified projects list",
+        "schema": {
+          "$schema": "ProjectMinifyResponse"
+        }
+      },
+      "GetReportDetailResponse": {
+        "description": "Successfully fetched report details",
+        "schema": {
+          "type": "object",
+          "required": [
+            "data",
+            "report_filters",
+            "dynamic_filters",
+            "report_data",
+            "project"
+          ],
+          "properties": {
+            "data": {
+              "$schema": "ReportDetail"
+            },
+            "report_filters": {
+              "$schema": "ReportFiltersDetail"
+            },
+            "dynamic_filters": {
+              "$schema": "DynamicFilters"
+            },
+            "report_data": {
+              "$schema": "ReportData"
+            },
+            "project": {
+              "$schema": "ReportProjectDetail"
+            }
+          }
+        }
+      },
+      "ReportSummaryResponse": {
+        "description": "Successful response for report details",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "example": true
+            }
+          },
+          "required": [
+            "success"
+          ]
+        }
+      },
+      "GetReportTestCases": {
+        "description": "Successfully fetched report testcases details",
+        "schema": {
+          "type": "object",
+          "required": [
+            "success",
+            "selection_data"
+          ],
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "example": true
+            },
+            "selection_data": {
+              "$schema": "SelectionData"
+            },
+            "selection": {
+              "type": "object",
+              "description": "the primary project's persisted folder-structured test-case selection (with select_all / per-folder flags + unique_test_case_count), in the same shape as the test-run edit/selection endpoint. `{}` when the report has no saved selection for the primary project. Used by the Edit dialog to re-check saved test cases (including folder/project-level select_all, which the flat ids cannot represent).",
+              "example": {
+                "select_all": false,
+                "folders": {
+                  "827": {
+                    "test_case_select_all": false,
+                    "selected_test_cases": [
+                      1515
+                    ],
+                    "deselected_test_cases": []
+                  }
+                },
+                "unique_test_case_count": 1
+              }
+            },
+            "shared_selection": {
+              "type": "object",
+              "description": "per-project folder-structured selection for the report's non-primary projects, keyed by project id ({ \"<project_id>\": <selection> }). Present only for cross-project Test Case Activity reports; `{}` otherwise.",
+              "example": {
+                "10209": {
+                  "select_all": true,
+                  "folders": {},
+                  "unique_test_case_count": 2
+                }
+              }
+            }
+          }
+        }
+      },
+      "SharedStepsIDResponse": {
+        "description": "Response containing details of a specific shared step by ID.",
+        "schema": {
+          "type": "object",
+          "required": [
+            "data",
+            "success"
+          ],
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "created_by": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "full_name"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "full_name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "updated_by": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "full_name"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "full_name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "shared_step_details": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "SharedStepDetail"
+                  }
+                }
+              },
+              "required": [
+                "created_by",
+                "id",
+                "shared_step_details",
+                "title",
+                "updated_by"
+              ]
+            },
+            "success": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "SharedStepsGetResponse": {
+        "description": "Response containing a list of shared steps with pagination info.",
+        "schema": {
+          "type": "object",
+          "required": [
+            "data",
+            "info",
+            "success"
+          ],
+          "properties": {
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "created_by": {
+                    "type": "object",
+                    "required": [
+                      "id",
+                      "full_name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "full_name": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "updated_by": {
+                    "type": "object",
+                    "required": [
+                      "id",
+                      "full_name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "full_name": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "test_case_count": {
+                    "type": "integer",
+                    "description": "Number of test cases using this shared step"
+                  },
+                  "step_count": {
+                    "type": "integer",
+                    "description": "Number of steps in this shared step"
+                  }
+                },
+                "required": [
+                  "created_by",
+                  "id",
+                  "step_count",
+                  "test_case_count",
+                  "title",
+                  "updated_by"
+                ]
+              }
+            },
+            "info": {
+              "type": "object",
+              "properties": {
+                "page": {
+                  "type": "integer",
+                  "description": "Current page number."
+                },
+                "page_size": {
+                  "type": "integer",
+                  "description": "Number of items per page."
+                },
+                "count": {
+                  "description": "Total number of shared steps"
+                },
+                "prev": {
+                  "type": "integer",
+                  "description": "Previous page number if applicable; null otherwise.",
+                  "nullable": true
+                },
+                "next": {
+                  "type": "integer",
+                  "description": "Next page number if applicable; null otherwise.",
+                  "nullable": true
+                }
+              },
+              "required": [
+                "count",
+                "next",
+                "page",
+                "page_size",
+                "prev"
+              ]
+            },
+            "pre_fetched_shared_step": {
+              "type": "object",
+              "description": "Pre-fetched details for the first shared step (when pre_fetch=true)",
+              "nullable": true,
+              "required": [
+                "shared_step_details",
+                "page_info"
+              ],
+              "properties": {
+                "shared_step_details": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "SharedStepDetail"
+                  }
+                },
+                "page_info": {
+                  "type": "object",
+                  "properties": {
+                    "page": {
+                      "type": "integer",
+                      "description": "Current page number."
+                    },
+                    "page_size": {
+                      "type": "integer",
+                      "description": "Number of items per page."
+                    },
+                    "count": {
+                      "description": "Total number of step details"
+                    },
+                    "prev": {
+                      "type": "integer",
+                      "description": "Previous page number if applicable; null otherwise.",
+                      "nullable": true
+                    },
+                    "next": {
+                      "type": "integer",
+                      "description": "Next page number if applicable; null otherwise.",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "count",
+                    "next",
+                    "page",
+                    "page_size",
+                    "prev"
+                  ]
+                }
+              }
+            },
+            "success": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "TestCaseCountTrend": {
+        "description": "The response contains the trend data for each test case category over the months.",
+        "schema": {
+          "type": "object",
+          "required": [
+            "data",
+            "empty_data",
+            "order"
+          ],
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "Accessibility": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Functional": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Acceptance": {
+                  "$schema": "TestCaseTrend"
+                },
+                "API": {
+                  "$schema": "TestCaseTrend"
+                },
+                "cfValue": {
+                  "$schema": "TestCaseTrend"
+                },
+                "cjcustomfieldValue": {
+                  "$schema": "TestCaseTrend"
+                },
+                "cjfield": {
+                  "$schema": "TestCaseTrend"
+                },
+                "cjnew": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Compatibility": {
+                  "$schema": "TestCaseTrend"
+                },
+                "DB": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Destructive": {
+                  "$schema": "TestCaseTrend"
+                },
+                "MIddleware": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Other": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Performance": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Regression": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Security": {
+                  "$schema": "TestCaseTrend"
+                },
+                "small case": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Smoke \\u0026 Sanity": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Smoke only": {
+                  "$schema": "TestCaseTrend"
+                },
+                "UI": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Usability": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Visual": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Automated": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Manual": {
+                  "$schema": "TestCaseTrend"
+                },
+                "Total": {
+                  "$schema": "TestCaseTrend"
+                }
+              }
+            },
+            "empty_data": {
+              "type": "boolean"
+            },
+            "order": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "HistoryDiffResponse": {
+        "description": "Response containing the diff of test case steps between two histories.",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            },
+            "diff": {
+              "type": "object",
+              "required": [
+                "test_case_steps"
+              ],
+              "properties": {
+                "test_case_steps": {
+                  "type": "object",
+                  "properties": {
+                    "old": {
+                      "type": "array",
+                      "items": {
+                        "$schema": "TestCaseDiffStep"
+                      }
+                    },
+                    "new": {
+                      "type": "array",
+                      "items": {
+                        "$schema": "TestCaseDiffStep"
+                      }
+                    }
+                  }
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "old": {
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "name"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "colour": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "new": {
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "name"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "links": {
+              "type": "object",
+              "example": {
+                "99": "/api/v1/projects/10000/test-cases/1/histories/99",
+                "100": "/api/v1/projects/10000/test-cases/1/histories/100"
+              }
+            }
+          }
+        }
+      },
+      "TestCaseTypeSplit": {
+        "description": "Test case count split by case type",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "y": {
+                    "type": "integer"
+                  },
+                  "value": {
+                    "type": "integer"
+                  },
+                  "field": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "empty_data": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "TestResultCustomFieldsResponse": {
+        "description": "Successfully retrieved custom fields for test results",
+        "schema": {
+          "$schema": "TestResultCustomFieldsResponse"
+        }
+      },
+      "TestResultListResponse": {
+        "description": "List of test results",
+        "schema": {
+          "type": "object",
+          "required": [
+            "success",
+            "test-results",
+            "info",
+            "unique_issues"
+          ],
+          "properties": {
+            "success": {
+              "type": "boolean"
+            },
+            "test-results": {
+              "type": "array",
+              "items": {
+                "$schema": "TestResult"
+              }
+            },
+            "info": {
+              "$schema": "PageInfo"
+            },
+            "unique_issues": {
+              "type": "array",
+              "example": [],
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "TestRunFormFieldsResponse": {
+        "description": "Successfully retrieved test result form fields",
+        "schema": {
+          "$schema": "TestRunFormFieldsResponse"
+        }
+      },
+      "TestRunsSelectionResponse": {
+        "description": "Successfully retrieved test runs",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "example": true
+            },
+            "test_cases": {
+              "type": "array",
+              "items": {
+                "$schema": "TestCase"
+              }
+            },
+            "info": {
+              "$schema": "PageInfo"
+            }
+          }
+        }
+      },
+      "FilterListResponse": {
+        "description": "Successfully retrieved list of filters",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "array",
+              "description": "Array of filter objects",
+              "items": {
+                "$schema": "Filter"
+              }
+            },
+            "info": {
+              "$schema": "PageInfo"
+            },
+            "success": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "FolderDetailsResponse": {
+        "description": "Response containing folder details including subfolders, counts, and links.",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "folders": {
+              "type": "array",
+              "items": {
+                "$schema": "Folder"
+              }
+            },
+            "self": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "project_id": {
+                  "type": "integer"
+                },
+                "group_id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "parent_id": {
+                  "type": "integer"
+                },
+                "notes": {
+                  "type": "string"
+                },
+                "is_automation": {
+                  "type": "boolean"
+                },
+                "cases_count": {
+                  "type": "integer"
+                },
+                "total_cases_count": {
+                  "type": "integer"
+                },
+                "sub_folders_count": {
+                  "type": "integer"
+                },
+                "contents": {
+                  "type": "array",
+                  "items": {
+                    "$schema": "Folder"
+                  }
+                },
+                "links": {
+                  "type": "object",
+                  "properties": {
+                    "self": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "parent_id": {
+              "type": "integer"
+            },
+            "ancestors": {
+              "type": "object",
+              "nullable": true
+            },
+            "test_cases": {
+              "type": "object",
+              "nullable": true
+            },
+            "info": {
+              "$schema": "PageInfo"
+            },
+            "success": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "TagsSearchResponse": {
+        "description": "Tags successfully retrieved",
+        "schema": {
+          "type": "object",
+          "required": [
+            "tags",
+            "tag_objects",
+            "info"
+          ],
+          "properties": {
+            "tags": {
+              "type": "array",
+              "description": "Simple array of tag names (for backward compatibility)",
+              "example": [
+                "AI Generated",
+                "AI Generated Details"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "tag_objects": {
+              "type": "array",
+              "description": "Detailed tag objects with metadata",
+              "items": {
+                "$schema": "Tag"
+              }
+            },
+            "info": {
+              "$schema": "PageInfo"
+            }
+          }
+        }
+      },
+      "ProjectUsersSearchResponse": {
+        "description": "Project users successfully retrieved",
+        "schema": {
+          "type": "object",
+          "required": [
+            "users",
+            "info"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "description": "List of users with access to the project",
+              "items": {
+                "$schema": "ProjectUserDetail"
+              }
+            },
+            "info": {
+              "$schema": "PageInfo"
+            }
+          }
+        }
+      },
+      "FilterUpdateResponse": {
+        "description": "Successfully updated the filter",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$schema": "Filter"
+            },
+            "success": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "UpdateReportResponse": {
+        "description": "Successfully updated scheduled report",
+        "schema": {
+          "$schema": "ReportUpdateResponse"
+        }
+      },
+      "GenericAttachmentsResponse": {
+        "description": "Attachments successfully uploaded",
+        "schema": {
+          "type": "object",
+          "required": [
+            "generic_attachment"
+          ],
+          "properties": {
+            "generic_attachment": {
+              "type": "array",
+              "description": "List of uploaded attachments with metadata",
+              "items": {
+                "$schema": "GenericAttachment"
+              }
+            }
+          }
+        }
+      }
+    },
+    "paging": {
+      "POST /api/v1/projects/{project_id}/test-cases/bulk-archive": {
+        "page": "p"
+      },
+      "POST /api/v1/projects/{project_id}/test-cases/bulk-copy": {
+        "page": "p"
+      },
+      "POST /api/v1/projects/{project_id}/test-cases/bulk-delete": {
+        "page": "p"
+      },
+      "POST /api/v1/projects/{project_id}/test-cases/bulk-edit": {
+        "page": "p"
+      },
+      "PATCH /api/v1/projects/{project_id}/test-cases": {
+        "page": "p"
+      },
+      "POST /api/v1/projects/{project_id}/test-cases/bulk-move": {
+        "page": "p"
+      },
+      "POST /api/v1/projects/{project_id}/test-cases/bulk-retrieve": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/{entity_type}/custom-fields/{field_id}": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/datasets/{uuid}/test-cases": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/datasets/variables": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/basic": {
+        "page": "p",
+        "size": "count",
+        "max": 300
+      },
+      "GET /api/v1/projects/minify": {
+        "page": "p",
+        "size": "count",
+        "max": 300
+      },
+      "GET /api/v1/projects/{project_id}/reports/{report_id}": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/reports/{report_id}/{section_name}": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/reports/{report_id}/detail/{report_type}": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/folders": {
+        "page": "p",
+        "size": "per_page",
+        "max": 100
+      },
+      "GET /api/v1/projects/{project_id}/shared-steps/{shared_step_id}": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/shared-steps": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/test-case/{field_name}": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/test-cases": {
+        "page": "p",
+        "size": "per_page",
+        "max": 100
+      },
+      "GET /api/v1/projects/{project_id}/test-plans/{test_plan_id}/test-runs": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/test-results/custom-fields": {
+        "page": "p",
+        "size": "per_page",
+        "max": 100
+      },
+      "GET /api/v1/projects/{project_id}/test-plans/archived_test_plans": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/datasets": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/ai-duplicates": {
+        "page": "page"
+      },
+      "GET /api/v1/projects/{project_id}/exploratory-sessions/{session_id}/defects": {
+        "page": "page",
+        "size": "per_page",
+        "max": 100
+      },
+      "GET /api/v1/projects/{project_id}/exploratory-sessions/{session_id}/logs": {
+        "page": "page",
+        "size": "per_page",
+        "max": 100
+      },
+      "GET /api/v1/projects/{project_id}/exploratory-sessions": {
+        "page": "page",
+        "size": "per_page",
+        "max": 100
+      },
+      "GET /api/v1/projects/{project_id}/filter": {
+        "page": "page"
+      },
+      "GET /api/v1/projects/{project_id}/folder/{folder_id}/test-cases": {
+        "page": "p",
+        "size": "per_page",
+        "max": 100
+      },
+      "GET /api/v1/projects": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/reports/schedules": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/test-case/tags-v2": {
+        "page": "p"
+      },
+      "GET /api/v1/admin-v2/settings/templates": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/test-plans": {
+        "page": "p"
+      },
+      "GET /api/v1/admin-v2/settings/fields": {
+        "page": "p"
+      },
+      "PATCH /api/v1/projects/{project_id}/folder/{folder_id}/test-cases/reorder": {
+        "page": "page"
+      },
+      "POST /api/v1/projects/{project_id}/ai-duplicates/search-v2": {
+        "page": "page"
+      },
+      "GET /api/v1/group/{entity_type}/tags": {
+        "page": "p"
+      },
+      "GET /api/v1/projects/{project_id}/{entity}/search": {
+        "page": "p",
+        "size": "page_size",
+        "max": 100
+      },
+      "POST /api/v1/projects/{project_id}/{entity}/search-v2": {
+        "page": "p",
+        "size": "per_page",
+        "max": 100
+      },
+      "GET /api/v1/projects/{project_id}/users/search": {
+        "page": "p",
+        "size": "page_size",
+        "max": 100
+      },
+      "GET /api/v1/projects/{project_id}/test-case/tags/search": {
+        "page": "p",
+        "size": "page_size",
+        "max": 100
+      },
+      "POST /api/v1/projects/{project_id}/reports/{report_id}/drilldown": {
+        "page": "p",
+        "size": "per_page",
+        "max": 100
+      }
+    },
+    "entities": {
+      "activity": {
+        "entity": "activity",
+        "title": "Activity feed (audit trail)",
+        "aliases": [
+          "activity",
+          "activities",
+          "activity feed",
+          "audit log",
+          "audit trail",
+          "history feed",
+          "who changed"
+        ],
+        "id_convention": "integer",
+        "parents": [],
+        "relations": [
+          {
+            "entity": "project",
+            "via": "scopes events"
+          },
+          {
+            "entity": "user",
+            "via": "actor of an event"
+          },
+          {
+            "entity": "test_case",
+            "via": "subject of an event"
+          },
+          {
+            "entity": "test_run",
+            "via": "subject of an event"
+          }
+        ],
+        "capabilities": [
+          "list_activity_events_v1"
+        ]
+      },
+      "attachment": {
+        "entity": "attachment",
+        "title": "Attachments",
+        "aliases": [
+          "attachment",
+          "file",
+          "attachments",
+          "blob"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_case",
+            "via": "attached to"
+          },
+          {
+            "entity": "result",
+            "via": "attached to"
+          }
+        ],
+        "capabilities": [
+          "delete_test_case_attachment",
+          "get_test_case_attachments_v1",
+          "upload_a_i_attachments",
+          "upload_generic_attachments",
+          "upload_test_case_attachments_v1"
+        ]
+      },
+      "configuration": {
+        "entity": "configuration",
+        "title": "Configurations",
+        "aliases": [
+          "config",
+          "configuration",
+          "environment",
+          "browser",
+          "os",
+          "device"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_run",
+            "via": "case status tracked against"
+          }
+        ],
+        "capabilities": [
+          "create_configuration_v1",
+          "get_configurations_v1"
+        ]
+      },
+      "custom_field": {
+        "entity": "custom_field",
+        "title": "Custom fields & system fields",
+        "aliases": [
+          "custom field",
+          "custom fields",
+          "field",
+          "system field"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_case",
+            "via": "extends"
+          },
+          {
+            "entity": "result",
+            "via": "extends"
+          }
+        ],
+        "capabilities": [
+          "create_custom_field_dataset_option_v2",
+          "create_custom_field_dataset_v2",
+          "create_custom_field_definition_v2",
+          "delete_custom_field_dataset_option_v2",
+          "delete_custom_field_dataset_v2",
+          "delete_custom_field_definition_v2",
+          "get_custom_field_dataset_v2",
+          "get_custom_field_definition_v2",
+          "get_custom_field_values_v1",
+          "get_project_id_custom_fields_v2_v1",
+          "get_test_results_custom_fields_v1",
+          "list_custom_field_dataset_options_v2",
+          "list_workspace_fields_v2",
+          "update_custom_field_dataset_option_v2",
+          "update_custom_field_dataset_project_mapping_v2",
+          "update_custom_field_definition_v2"
+        ]
+      },
+      "dataset": {
+        "entity": "dataset",
+        "title": "Dataset",
+        "aliases": [
+          "datasets",
+          "data-driven-data",
+          "dds"
+        ],
+        "id_convention": "uuid",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_case",
+            "via": "drives"
+          },
+          {
+            "entity": "variable",
+            "via": "has columns"
+          }
+        ],
+        "capabilities": [
+          "create_dataset",
+          "delete_dataset",
+          "get_dataset",
+          "get_dataset_linked_test_cases",
+          "get_dataset_variables",
+          "import_dataset_c_s_v",
+          "list_datasets",
+          "update_dataset"
+        ]
+      },
+      "duplicate": {
+        "entity": "duplicate",
+        "title": "Duplicate recommendation (AI dedupe)",
+        "aliases": [
+          "duplicate",
+          "duplicates",
+          "dedupe",
+          "deduplication",
+          "duplicate recommendation",
+          "ai duplicates",
+          "redundant test cases"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_case",
+            "via": "links the pair it believes are duplicates"
+          }
+        ],
+        "capabilities": [
+          "discard_duplicate_v1",
+          "get_dedupe_status_v1",
+          "get_duplicate_source_test_case_v1",
+          "get_duplicate_v1",
+          "list_duplicates_v1",
+          "resolve_duplicate_v1",
+          "search_duplicates_v1"
+        ]
+      },
+      "exploratory_session": {
+        "entity": "exploratory_session",
+        "title": "Exploratory session",
+        "aliases": [
+          "session",
+          "exploratory",
+          "et-session"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "project",
+          "folder"
+        ],
+        "relations": [
+          {
+            "entity": "exploratory_log",
+            "via": "records"
+          },
+          {
+            "entity": "issue",
+            "via": "links defects"
+          },
+          {
+            "entity": "configuration",
+            "via": "runs against"
+          },
+          {
+            "entity": "test_case",
+            "via": "notes become"
+          }
+        ],
+        "capabilities": [
+          "clone_exploratory_session_v1",
+          "close_exploratory_session",
+          "create_exploratory_session",
+          "create_exploratory_session_log",
+          "delete_exploratory_session",
+          "delete_exploratory_session_log",
+          "get_exploratory_session",
+          "list_exploratory_session_defects",
+          "list_exploratory_session_logs",
+          "list_exploratory_sessions",
+          "update_exploratory_session",
+          "update_exploratory_session_log"
+        ]
+      },
+      "filter": {
+        "entity": "filter",
+        "title": "Saved filter view",
+        "aliases": [
+          "filter",
+          "filters",
+          "saved view",
+          "saved filter",
+          "view"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_case",
+            "via": "filters"
+          },
+          {
+            "entity": "test_run",
+            "via": "filters"
+          },
+          {
+            "entity": "test_plan",
+            "via": "filters"
+          }
+        ],
+        "capabilities": [
+          "create_filter",
+          "delete_filter",
+          "get_filter",
+          "list_filters",
+          "update_filter"
+        ]
+      },
+      "folder": {
+        "entity": "folder",
+        "title": "Folder",
+        "aliases": [
+          "dir",
+          "directory"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "folder",
+            "via": "nests under"
+          },
+          {
+            "entity": "test_case",
+            "via": "organises"
+          }
+        ],
+        "capabilities": [
+          "copy_folder",
+          "create_root_folder_v1",
+          "create_sub_folder_v1",
+          "delete_folder_and_contents",
+          "get_folder_remove_summary",
+          "get_folder_tree_v1",
+          "get_root_folders_v1",
+          "list_folder_contents",
+          "move_folder_v1",
+          "rename_folder_v1",
+          "reorder_folders",
+          "undo_remove_folder"
+        ]
+      },
+      "project": {
+        "entity": "project",
+        "title": "Project",
+        "aliases": [
+          "pr",
+          "workspace"
+        ],
+        "id_convention": "PR-NNN",
+        "parents": [],
+        "relations": [
+          {
+            "entity": "folder"
+          },
+          {
+            "entity": "test_case"
+          },
+          {
+            "entity": "test_run"
+          },
+          {
+            "entity": "test_plan"
+          },
+          {
+            "entity": "configuration",
+            "via": "scopes"
+          },
+          {
+            "entity": "custom_field",
+            "via": "scopes"
+          },
+          {
+            "entity": "user",
+            "via": "grants access to"
+          }
+        ],
+        "capabilities": [
+          "create_project_v1",
+          "export_dashboard_analytics",
+          "get_active_test_runs_info_v1",
+          "get_automation_stats_v1",
+          "get_closed_test_runs_info_v1",
+          "get_closed_test_runs_split_v1",
+          "get_entity_filter_details_v1",
+          "get_issues_count_info_v1",
+          "get_project_by_integer_id_v1",
+          "get_project_settings",
+          "get_project_users_v2_v1",
+          "get_projects_basic_v1",
+          "get_projects_minify_v1",
+          "get_test_case_count_trend_v1",
+          "get_test_case_type_split_v1",
+          "list_projects_v1",
+          "search_project_entities",
+          "update_project_settings"
+        ]
+      },
+      "report": {
+        "entity": "report",
+        "title": "Report",
+        "aliases": [
+          "reports",
+          "scheduled-report",
+          "schedule",
+          "analytics-report"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_run",
+            "via": "summarises"
+          },
+          {
+            "entity": "test_plan",
+            "via": "summarises"
+          },
+          {
+            "entity": "test_case",
+            "via": "traces (traceability)"
+          },
+          {
+            "entity": "user",
+            "via": "mailed to"
+          }
+        ],
+        "capabilities": [
+          "create_report",
+          "delete_report_schedule",
+          "download_report",
+          "get_exploratory_session_summary_v1",
+          "get_report_attachment_url",
+          "get_report_detail",
+          "get_report_section_v1",
+          "get_report_summary_by_type",
+          "get_selected_report_testcases",
+          "list_schedules",
+          "send_report_email_now_v1",
+          "update_report",
+          "user_workload_drilldown"
+        ]
+      },
+      "result": {
+        "entity": "result",
+        "title": "Result",
+        "aliases": [
+          "outcome",
+          "execution-result",
+          "test-result"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "test_run",
+          "test_case"
+        ],
+        "relations": [
+          {
+            "entity": "test_case",
+            "via": "references"
+          },
+          {
+            "entity": "test_run",
+            "via": "references"
+          }
+        ],
+        "capabilities": [
+          "bulk_delete_test_results_v1",
+          "create_step_result_v1",
+          "create_test_result_for_test_case",
+          "delete_test_result_v1",
+          "get_test_results_for_test_case",
+          "update_latest_test_result_for_test_case"
+        ]
+      },
+      "shared_step": {
+        "entity": "shared_step",
+        "title": "Shared step",
+        "aliases": [
+          "shared step",
+          "shared steps",
+          "reusable step",
+          "step template"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_case",
+            "via": "reused by"
+          }
+        ],
+        "capabilities": [
+          "create_shared_step_v1",
+          "delete_shared_step_v1",
+          "get_shared_steps_by_i_d_v1",
+          "get_shared_steps_v1",
+          "update_shared_step_v1"
+        ]
+      },
+      "tag": {
+        "entity": "tag",
+        "title": "Tag",
+        "aliases": [
+          "tags",
+          "label",
+          "labels"
+        ],
+        "id_convention": "name",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_case",
+            "via": "labels"
+          },
+          {
+            "entity": "test_run",
+            "via": "labels"
+          },
+          {
+            "entity": "test_plan",
+            "via": "labels"
+          }
+        ],
+        "capabilities": [
+          "bulk_edit_test_cases_v2",
+          "get_test_case_tags",
+          "list_test_case_tags_v1",
+          "merge_tags_v1",
+          "search_group_tags",
+          "search_test_case_tags"
+        ]
+      },
+      "test_case": {
+        "entity": "test_case",
+        "title": "Test case",
+        "aliases": [
+          "tc",
+          "case",
+          "test case"
+        ],
+        "id_convention": "TC-NNN",
+        "parents": [
+          "folder",
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_run",
+            "via": "executed in"
+          },
+          {
+            "entity": "result",
+            "via": "produces"
+          },
+          {
+            "entity": "custom_field",
+            "via": "extended by"
+          },
+          {
+            "entity": "attachment",
+            "via": "has"
+          },
+          {
+            "entity": "tag",
+            "via": "labelled by"
+          },
+          {
+            "entity": "shared_step",
+            "via": "reuses"
+          }
+        ],
+        "capabilities": [
+          "bulk_archive_test_cases_by_project",
+          "bulk_copy_test_cases",
+          "bulk_delete_test_cases",
+          "bulk_edit_test_cases",
+          "bulk_edit_test_cases_in_test_run",
+          "bulk_move_test_cases",
+          "bulk_retrieve_test_cases",
+          "create_bulk_test_cases_v1",
+          "create_test_case_v1",
+          "create_test_cases",
+          "edit_test_case_partial_v1",
+          "edit_test_case_v1",
+          "get_archived_test_cases",
+          "get_system_field_values_v1",
+          "get_test_case_by_integer_id_v1",
+          "get_test_case_detail",
+          "get_test_cases_v1",
+          "list_folder_test_cases_v1",
+          "reorder_test_cases_by_folder_v1",
+          "search_project_entities_v2",
+          "search_test_cases_by_folder_v1"
+        ]
+      },
+      "test_plan": {
+        "entity": "test_plan",
+        "title": "Test plan (and sub-plan)",
+        "aliases": [
+          "tp",
+          "plan",
+          "milestone",
+          "sub test plan",
+          "subplan",
+          "stp"
+        ],
+        "id_convention": "TP-NNN (sub-plan STP-NNN)",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_run",
+            "via": "groups"
+          },
+          {
+            "entity": "test_plan",
+            "via": "parent/child via parent_plan_id"
+          }
+        ],
+        "capabilities": [
+          "bulk_archive_test_plans_v1",
+          "bulk_retrieve_test_plans_v1",
+          "clone_test_plan_v1",
+          "create_test_plan_v1",
+          "delete_test_plan_v1",
+          "get_archived_test_plan_count_v1",
+          "get_test_plan_by_integer_id_v1",
+          "get_test_plan_execution_trend_v1",
+          "get_test_plan_linked_sessions_chart_data_v1",
+          "get_test_plan_test_runs_v1",
+          "list_archived_test_plans_v1",
+          "list_test_plans_v1",
+          "unlink_test_runs_from_test_plan",
+          "update_test_plan_v1"
+        ]
+      },
+      "test_run": {
+        "entity": "test_run",
+        "title": "Test run",
+        "aliases": [
+          "tr",
+          "run",
+          "execution"
+        ],
+        "id_convention": "TR-NNN",
+        "parents": [
+          "test_plan",
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_case",
+            "via": "includes"
+          },
+          {
+            "entity": "result",
+            "via": "produces"
+          },
+          {
+            "entity": "configuration",
+            "via": "runs against"
+          },
+          {
+            "entity": "test_plan",
+            "via": "grouped by"
+          }
+        ],
+        "capabilities": [
+          "assign_test_run_owner",
+          "bulk_assign_test_cases_to_test_run",
+          "clone_test_run",
+          "close_test_run_v1",
+          "count_run_selection_v1",
+          "create_test_run_v1",
+          "delete_v1_test_run",
+          "edit_test_run",
+          "get_closed_test_runs",
+          "get_test_cases_for_v1_test_run",
+          "get_test_run_by_integer_id_v1",
+          "get_test_run_cases_v1",
+          "get_test_runs_form_fields_v1",
+          "get_test_runs_selection",
+          "get_test_runs_v1"
+        ]
+      },
+      "user": {
+        "entity": "user",
+        "title": "User",
+        "aliases": [
+          "users",
+          "member",
+          "assignee",
+          "owner"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "project",
+            "via": "member of"
+          },
+          {
+            "entity": "test_run",
+            "via": "assigned to"
+          },
+          {
+            "entity": "test_case",
+            "via": "owns"
+          }
+        ],
+        "capabilities": [
+          "get_group_users_v2_v1",
+          "search_project_users"
+        ]
+      },
+      "version": {
+        "entity": "version",
+        "title": "Test case version",
+        "aliases": [
+          "history",
+          "histories",
+          "revision",
+          "version-history"
+        ],
+        "id_convention": "integer",
+        "parents": [
+          "test_case",
+          "project"
+        ],
+        "relations": [
+          {
+            "entity": "test_case",
+            "via": "versions"
+          },
+          {
+            "entity": "user",
+            "via": "changed by"
+          }
+        ],
+        "capabilities": [
+          "get_test_case_histories_v1",
+          "get_test_case_history_diff_v1",
+          "get_test_case_history_v1",
+          "restore_history_v1"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the generated capability index for BrowserStack Test Management, so the capability-registry tool surface has a product to serve.

Targets `feat/capability-registry` rather than `main`: the code that reads this file lives there, and neither half is useful without the other.

**This is a build artifact, not authored code.** It is the output of the export pipeline, and every field in it has already passed that pipeline's outbound boundary — no `x-atlas-permission`, no internal parameter `target` names, no page/count parameter names, no raw `key_facts`, no route-dense prose. Reviewing it line by line is not the intent; the boundary gates and their tests live on the generating side.

### What it contains

| | |
|---|---|
| capabilities | 173 (88 read, 69 write, 16 destructive) |
| entities | 19 |
| named responses | 53 |
| named schemas | 75 |

Responses and schemas are stored once in product-level tables and referenced from the capabilities, which is why the file is roughly a third of the size it would be inlined.

### Provenance

- harness: browserstack/agent-platform-harness-common#308 @ `83c68cd`
- `build_id`: `83525474_2026-09-02T12:13:05Z`
- `version`: `1.0`

### Notes for review

- **No host is baked in.** tm's `product.yaml` leaves `base_url` to config on purpose: a single declared origin would send every EU and IN account to the US host, a failure invisible to anyone testing from a US account. The server discovers the account's region instead.
- The only absolute URLs in the file are `https://example.com/...` placeholders inside schema examples.
- Split out so the 19k-line generated file does not sit in the middle of a code review. The base branch already carries `package.json`'s `files` entry that ships this directory, and a copy of this export as a test fixture — the suite asserts against a real export (schema counts, reference depth, absence of a declared host) rather than a synthetic one.