### PR TITLE
feat(automate): add listSessions tool call

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,18 +426,25 @@ As of now we support 44 tools.
   Get screenshots from Automate session ID abc123xyz for my desktop test run
   ```
 
+ 18. `listSessionIds` — List Automate/App Automate session hashed IDs for a REST hashed build ID (dashboard URL). This is **not** the observability UUID from `getBuildId` / `listBuildId`. If you only have that UUID, use `hashed_id` from `fetchBuildInsights` when present. Same build-id family as App Automate `getFailureLogs`. Returned `sessionId` values work with `getFailureLogs`, `fetchAutomationScreenshots`, and `fetchSelfHealedSelectors`.
+  **Prompt example**
+
+  ```text
+  List session IDs for Automate hashed build ID ca9cccc228cf0e3ff3cb90dd62e2e2bfb4b20bc7
+  ```
+
 ---
 
 ## 🔍 Observability
 
- 18. `getFailureLogs` — Retrieve error logs for Automate/App Automate sessions (optionally by Build ID for App Automate).
+ 19. `getFailureLogs` — Retrieve error logs for Automate/App Automate sessions (optionally by hashed Build ID for App Automate; if you only have an observability UUID, use `hashed_id` from `fetchBuildInsights` when present).
   **Prompt example**
 
   ```text
   Get the error logs from the session ID: 21a864032a7459f1e7634222249b316759d6827f, Build ID: dt7ung4wmjittzff8kksrjadjax9gzvbscoyf9qn of App Automate test session
   ```
 
- 19. `fetchBuildInsights` — Fetch insights about a BrowserStack build by combining build details and quality-gate results.
+ 20. `fetchBuildInsights` — Fetch insights about a BrowserStack build by combining build details and quality-gate results. Includes `hashed_id` (Automate REST build id) when observability provides it or Automate REST can resolve it.
   **Prompt example**
 
   ```text
@@ -448,7 +455,7 @@ As of now we support 44 tools.
 
 ## 📱 App Live
 
- 20. `runAppLiveSession` — Start a manual app testing session on a real device in the cloud.
+ 21. `runAppLiveSession` — Start a manual app testing session on a real device in the cloud.
   **Prompt example**
 
   ```text
@@ -459,7 +466,7 @@ As of now we support 44 tools.
 
 ## 💻 Live
 
- 21. `runBrowserLiveSession` — Start a Live session for website testing on desktop or mobile browsers.
+ 22. `runBrowserLiveSession` — Start a Live session for website testing on desktop or mobile browsers.
   **Prompt example**
 
   ```text
@@ -470,21 +477,21 @@ As of now we support 44 tools.
 
 ## 📲 App Automate
 
- 22. `takeAppScreenshot` — Launch the app on a specified device and capture a quick verification screenshot to confirm your app has launched.
+ 23. `takeAppScreenshot` — Launch the app on a specified device and capture a quick verification screenshot to confirm your app has launched.
   **Prompt example**
 
   ```text
   Take a screenshot of my app on Google Pixel 6 with Android 12 while testing on App Automate. App file path: /Users/xyz/app-debug.apk
   ```
 
- 23. `runAppTestsOnBrowserStack` — Run pre-built native mobile test suites (Espresso/XCUITest) by direct upload of compiled .apk/.ipa test files.
+ 24. `runAppTestsOnBrowserStack` — Run pre-built native mobile test suites (Espresso/XCUITest) by direct upload of compiled .apk/.ipa test files.
   **Prompt example**
 
   ```text
   Run Espresso tests from /tests/checkout.zip on Galaxy S21 and Pixel 6 with Android 12. App path is /apps/beta-release.apk under project 'Checkout Flow'
   ```
 
- 24. `setupBrowserStackAppAutomateTests` — Set up BrowserStack App Automate SDK integration for Appium-based mobile app testing.
+ 25. `setupBrowserStackAppAutomateTests` — Set up BrowserStack App Automate SDK integration for Appium-based mobile app testing.
   **Prompt example**
 
   ```text
@@ -495,35 +502,35 @@ As of now we support 44 tools.
 
 ## ♿ Accessibility
 
- 25. `accessibilityExpert` — Ask the A11y Expert (WCAG 2.0/2.1/2.2, mobile/web usability, best practices).
+ 26. `accessibilityExpert` — Ask the A11y Expert (WCAG 2.0/2.1/2.2, mobile/web usability, best practices).
   **Prompt example**
 
   ```text
   What WCAG guidelines apply to form field error messages on mobile web?
   ```
 
- 26. `startAccessibilityScan` — Start a web accessibility scan and retrieve a local CSV report path.
+ 27. `startAccessibilityScan` — Start a web accessibility scan and retrieve a local CSV report path.
   **Prompt example**
 
   ```text
   Run accessibility scan for "www.example.com"
   ```
 
- 27. `createAccessibilityAuthConfig` — Create an authentication configuration (form-based or basic) for accessibility scans behind a login.
+ 28. `createAccessibilityAuthConfig` — Create an authentication configuration (form-based or basic) for accessibility scans behind a login.
   **Prompt example**
 
   ```text
   Create a basic-auth accessibility config named 'site-login' for https://www.example.com with username testuser and password <password>
   ```
 
- 28. `getAccessibilityAuthConfig` — Retrieve an existing accessibility authentication configuration by ID.
+ 29. `getAccessibilityAuthConfig` — Retrieve an existing accessibility authentication configuration by ID.
   **Prompt example**
 
   ```text
   Get accessibility auth config with ID <config-id>
   ```
 
- 29. `fetchAccessibilityIssues` — Fetch accessibility issues from a completed scan, with pagination support.
+ 30. `fetchAccessibilityIssues` — Fetch accessibility issues from a completed scan, with pagination support.
   **Prompt example**
 
   ```text
@@ -534,49 +541,49 @@ As of now we support 44 tools.
 
 ## 🎨 Percy Visual Testing
 
- 30. `percyVisualTestIntegrationAgent` — Integrate Percy visual testing into a new project and demonstrate visual change detection with a step-by-step simulation.
+ 31. `percyVisualTestIntegrationAgent` — Integrate Percy visual testing into a new project and demonstrate visual change detection with a step-by-step simulation.
   **Prompt example**
 
   ```text
   Integrate Percy for this project
   ```
 
- 31. `expandPercyVisualTesting` — Set up or expand Percy visual testing coverage for existing projects (Percy Web Standalone and Percy Automate).
+ 32. `expandPercyVisualTesting` — Set up or expand Percy visual testing coverage for existing projects (Percy Web Standalone and Percy Automate).
   **Prompt example**
 
   ```text
   Expand Percy coverage for this project
   ```
 
- 32. `addPercySnapshotCommands` — Add Percy snapshot commands to the specified test files. _(not available in Remote MCP)_
+ 33. `addPercySnapshotCommands` — Add Percy snapshot commands to the specified test files. _(not available in Remote MCP)_
   **Prompt example**
 
   ```text
   Add Percy snapshot commands to my Cypress test files
   ```
 
- 33. `listTestFiles` — List all test files for a given set of directories. _(not available in Remote MCP)_
+ 34. `listTestFiles` — List all test files for a given set of directories. _(not available in Remote MCP)_
   **Prompt example**
 
   ```text
   List the test files under my ./tests directory
   ```
 
- 34. `runPercyScan` — Run a Percy visual test scan. _(not available in Remote MCP)_
+ 35. `runPercyScan` — Run a Percy visual test scan. _(not available in Remote MCP)_
   **Prompt example**
 
   ```text
   Run this Percy build
   ```
 
- 35. `fetchPercyChanges` — Retrieve and summarize visual changes detected by Percy AI between the latest and previous builds.
+ 36. `fetchPercyChanges` — Retrieve and summarize visual changes detected by Percy AI between the latest and previous builds.
   **Prompt example**
 
   ```text
   Summarize the visual changes Percy detected in my latest build
   ```
 
- 36. `managePercyBuildApproval` — Approve or reject a Percy build.
+ 37. `managePercyBuildApproval` — Approve or reject a Percy build.
   **Prompt example**
 
   ```text
@@ -587,56 +594,56 @@ As of now we support 44 tools.
 
 ## 🤖 BrowserStack AI Agents
 
- 37. `uploadProductRequirementFile` — Upload a PRD/screenshot/PDF and get a file mapping ID (used with `createTestCasesFromFile`). _(not available in Remote MCP)_
+ 38. `uploadProductRequirementFile` — Upload a PRD/screenshot/PDF and get a file mapping ID (used with `createTestCasesFromFile`). _(not available in Remote MCP)_
   **Prompt example**
 
   ```text
   Upload PRD from /Users/xyz/Desktop/login-flow.pdf and use BrowserStack AI to generate test cases
   ```
 
- 38. `createLCASteps` — Generate Low Code Automation (LCA) steps from a manual test case in Test Management.
+ 39. `createLCASteps` — Generate Low Code Automation (LCA) steps from a manual test case in Test Management.
   **Prompt example**
 
   ```text
   Convert the manual test case 'Add to Cart' in the 'Shopping App' project into LCA steps
   ```
 
- 39. `fetchSelfHealedSelectors` — Retrieve AI self-healed selectors (plus test source) to fix flaky tests caused by DOM changes.
+ 40. `fetchSelfHealedSelectors` — Retrieve AI self-healed selectors (plus test source) to fix flaky tests caused by DOM changes.
   **Prompt example**
 
   ```text
   Fetch and fix flaky test selectors in Automate session ID session_9482 using MCP
   ```
 
- 40. `prepareSelfHealingPlan` — Build a self-healing edit plan that bundles locator pairs with test source for your LLM to apply. Does NOT modify files itself.
+ 41. `prepareSelfHealingPlan` — Build a self-healing edit plan that bundles locator pairs with test source for your LLM to apply. Does NOT modify files itself.
   **Prompt example**
 
   ```text
   Prepare a self-healing plan from the self-healed selectors for my build
   ```
 
- 41. `fetchRCA` — Fetch AI Root Cause Analysis for your failed Automate/App-Automate tests (by numeric test ID). Suggests fixes only; never auto-applies.
+ 42. `fetchRCA` — Fetch AI Root Cause Analysis for your failed Automate/App-Automate tests (by numeric test ID). Suggests fixes only; never auto-applies.
   **Prompt example**
 
   ```text
   Fetch the root cause analysis for failed test IDs 101 and 102 on BrowserStack
   ```
 
- 42. `getBuildId` — Get the BrowserStack build ID for a given project and build name, scoped to your builds.
+ 43. `getBuildId` — Get the BrowserStack build ID for a given project and build name, scoped to your builds.
   **Prompt example**
 
   ```text
   Get the build ID for build 'nightly-regression' in project 'Checkout Flow'
   ```
 
- 43. `listBuildId` — Get the latest build ID for a project and build name, across all users (no user filter).
+ 44. `listBuildId` — Get the latest build ID for a project and build name, across all users (no user filter).
   **Prompt example**
 
   ```text
   Get the latest build ID for build 'nightly-regression' in project 'Checkout Flow'
   ```
 
- 44. `listTestIds` — List test IDs from a BrowserStack Automate build, filtered by status (passed/failed/pending/skipped).
+ 45. `listTestIds` — List test IDs from a BrowserStack Automate build, filtered by status (passed/failed/pending/skipped).
   **Prompt example**
 
   ```text

--- a/README.md
+++ b/README.md
@@ -426,11 +426,11 @@ As of now we support 44 tools.
   Get screenshots from Automate session ID abc123xyz for my desktop test run
   ```
 
- 18. `listSessionIds` — List Automate/App Automate session hashed IDs for a REST hashed build ID (dashboard URL). This is **not** the observability UUID from `getBuildId` / `listBuildId`. If you only have that UUID, use `hashed_id` from `fetchBuildInsights` when present. Same build-id family as App Automate `getFailureLogs`. Returned `sessionId` values work with `getFailureLogs`, `fetchAutomationScreenshots`, and `fetchSelfHealedSelectors`.
+ 18. `listSessions` — List Automate/App Automate sessions for a REST hashed build ID (dashboard URL), including hashed session IDs and session details (name, status, OS, browser/device, dashboard URL). This is **not** the observability UUID from `getBuildId` / `listBuildId`. If you only have that UUID, use `hashed_id` from `fetchBuildInsights` when present. Same build-id family as App Automate `getFailureLogs`. Returned `sessionId` values work with `getFailureLogs`, `fetchAutomationScreenshots`, and `fetchSelfHealedSelectors`.
   **Prompt example**
 
   ```text
-  List session IDs for Automate hashed build ID ca9cccc228cf0e3ff3cb90dd62e2e2bfb4b20bc7
+  List sessions for Automate hashed build ID ca9cccc228cf0e3ff3cb90dd62e2e2bfb4b20bc7
   ```
 
 ---

--- a/src/tools/automate-utils/list-session-ids.ts
+++ b/src/tools/automate-utils/list-session-ids.ts
@@ -1,0 +1,139 @@
+import { SessionType } from "../../lib/constants.js";
+import { getBrowserStackAuth } from "../../lib/get-auth.js";
+import { BrowserStackConfig } from "../../lib/types.js";
+import { apiClient } from "../../lib/apiClient.js";
+
+export const DEFAULT_SESSION_LIST_LIMIT = 10;
+
+export interface ListSessionIdsArgs {
+  sessionType: SessionType;
+  buildId: string;
+  limit?: number;
+  offset?: number;
+  status?: string;
+}
+
+export interface SessionIdRecord {
+  sessionId: string;
+  name?: string;
+  status?: string;
+  os?: string;
+  osVersion?: string;
+  browser?: string;
+  device?: string | null;
+  browserUrl?: string;
+}
+
+interface AutomationSessionPayload {
+  hashed_id?: string;
+  name?: string;
+  status?: string;
+  os?: string;
+  os_version?: string;
+  browser?: string;
+  device?: string | null;
+  browser_url?: string;
+}
+
+interface SessionListItem {
+  automation_session?: AutomationSessionPayload;
+}
+
+export function sessionsListUrl(
+  sessionType: SessionType,
+  buildId: string,
+): string {
+  const encodedBuildId = encodeURIComponent(buildId);
+  switch (sessionType) {
+    case SessionType.Automate:
+      return `https://api.browserstack.com/automate/builds/${encodedBuildId}/sessions.json`;
+    case SessionType.AppAutomate:
+      return `https://api-cloud.browserstack.com/app-automate/builds/${encodedBuildId}/sessions.json`;
+    default: {
+      const _exhaustive: never = sessionType;
+      throw new Error(`Unsupported session type: ${_exhaustive}`);
+    }
+  }
+}
+
+export function mapSessionRecords(
+  payload: unknown,
+  statusFilter?: string,
+): SessionIdRecord[] {
+  const items = Array.isArray(payload) ? payload : [];
+  const normalizedFilter = statusFilter?.trim().toLowerCase();
+
+  const records: SessionIdRecord[] = [];
+  for (const item of items) {
+    const session = (item as SessionListItem)?.automation_session;
+    if (!session) {
+      continue;
+    }
+    const sessionId = session.hashed_id?.trim();
+    if (!sessionId) {
+      continue;
+    }
+    if (
+      normalizedFilter &&
+      (session.status ?? "").toLowerCase() !== normalizedFilter
+    ) {
+      continue;
+    }
+    records.push({
+      sessionId,
+      name: session.name,
+      status: session.status,
+      os: session.os,
+      osVersion: session.os_version,
+      browser: session.browser,
+      device: session.device,
+      browserUrl: session.browser_url,
+    });
+  }
+  return records;
+}
+
+export async function listSessionIds(
+  args: ListSessionIdsArgs,
+  config: BrowserStackConfig,
+): Promise<SessionIdRecord[]> {
+  const buildId = args.buildId.trim();
+  if (!buildId) {
+    throw new Error("Hashed Automate/App Automate build ID is required");
+  }
+
+  const authString = getBrowserStackAuth(config);
+  const auth = Buffer.from(authString).toString("base64");
+  const limit = args.limit ?? DEFAULT_SESSION_LIST_LIMIT;
+  const params: Record<string, string | number> = { limit };
+  if (args.offset !== undefined) {
+    params.offset = args.offset;
+  }
+
+  const response = await apiClient.get({
+    url: sessionsListUrl(args.sessionType, buildId),
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Basic ${auth}`,
+    },
+    params,
+    raise_error: false,
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(
+        `Invalid hashed build ID "${buildId}" for ${args.sessionType}. ` +
+          "Use the Automate/App Automate dashboard hashed build id " +
+          "(same family as App Automate getFailureLogs buildId), not the " +
+          "observability UUID from getBuildId or listBuildId. " +
+          "If you only have an observability UUID, call fetchBuildInsights and use hashed_id when present.",
+      );
+    }
+    throw new Error(
+      `Failed to list sessions: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return mapSessionRecords(response.data, args.status);
+}

--- a/src/tools/automate-utils/resolve-hashed-build-id.ts
+++ b/src/tools/automate-utils/resolve-hashed-build-id.ts
@@ -1,0 +1,407 @@
+import { SessionType } from "../../lib/constants.js";
+import { getBrowserStackAuth } from "../../lib/get-auth.js";
+import { BrowserStackConfig } from "../../lib/types.js";
+import { apiClient } from "../../lib/apiClient.js";
+
+export const BUILD_LIST_PAGE_SIZE = 10;
+export const BUILD_LIST_MAX_BUILDS = 100;
+
+export interface ResolveHashedBuildIdArgs {
+  observabilityId: string;
+  sessionType?: SessionType;
+}
+
+export interface ResolvedHashedBuildId {
+  hashedBuildId: string;
+  sessionType: SessionType;
+  name: string;
+  observabilityId: string;
+}
+
+interface TraBuildPayload {
+  name?: string;
+  original_name?: string;
+  duration?: number;
+  started_at?: string;
+  hashed_id?: string;
+  automate_hashed_id?: string;
+  hashedId?: string;
+}
+
+interface AutomationBuildPayload {
+  hashed_id?: string;
+  name?: string;
+  duration?: number;
+  started_at?: string;
+  created_at?: string;
+}
+
+interface BuildListItem {
+  automation_build?: AutomationBuildPayload;
+}
+
+interface RestBuildCandidate {
+  hashedId: string;
+  name: string;
+  sessionType: SessionType;
+  duration?: number;
+  startedAtMs?: number;
+}
+
+export function parseObservabilityId(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("Observability ID is required");
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    const url = new URL(trimmed);
+    const segments = url.pathname.split("/").filter(Boolean);
+    const last = segments[segments.length - 1];
+    if (!last) {
+      throw new Error("Observability ID is required");
+    }
+    return last;
+  }
+
+  return trimmed;
+}
+
+export function buildsListUrl(sessionType: SessionType): string {
+  switch (sessionType) {
+    case SessionType.Automate:
+      return "https://api.browserstack.com/automate/builds.json";
+    case SessionType.AppAutomate:
+      return "https://api-cloud.browserstack.com/app-automate/builds.json";
+    default: {
+      const _exhaustive: never = sessionType;
+      throw new Error(`Unsupported session type: ${_exhaustive}`);
+    }
+  }
+}
+
+function authHeader(config: BrowserStackConfig): string {
+  const authString = getBrowserStackAuth(config);
+  return `Basic ${Buffer.from(authString).toString("base64")}`;
+}
+
+function looksLikeHashedId(value: string): boolean {
+  return /^[a-f0-9]{40}$/i.test(value.trim());
+}
+
+export function extractDirectHashedId(
+  payload: TraBuildPayload,
+): string | undefined {
+  const candidates = [
+    payload.hashed_id,
+    payload.automate_hashed_id,
+    payload.hashedId,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && looksLikeHashedId(candidate)) {
+      return candidate.trim();
+    }
+  }
+  return undefined;
+}
+
+function parseTimestampMs(value?: string): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+function productsToSearch(sessionType?: SessionType): SessionType[] {
+  if (!sessionType) {
+    return [SessionType.Automate, SessionType.AppAutomate];
+  }
+  switch (sessionType) {
+    case SessionType.Automate:
+      return [SessionType.Automate];
+    case SessionType.AppAutomate:
+      return [SessionType.AppAutomate];
+    default: {
+      const _exhaustive: never = sessionType;
+      throw new Error(`Unsupported session type: ${_exhaustive}`);
+    }
+  }
+}
+
+function namesMatch(buildName: string, expected?: string): boolean {
+  if (!expected) {
+    return false;
+  }
+  const build = buildName.trim();
+  const needle = expected.trim();
+  if (!needle) {
+    return false;
+  }
+  if (build === needle) {
+    return true;
+  }
+  return build.startsWith(`${needle} `) || build.startsWith(`${needle}\t`);
+}
+
+function matchKind(
+  buildName: string,
+  originalName?: string,
+  derivedName?: string,
+): "original" | "name" | undefined {
+  if (namesMatch(buildName, originalName)) {
+    return "original";
+  }
+  if (namesMatch(buildName, derivedName)) {
+    return "name";
+  }
+  return undefined;
+}
+
+function pickByCloseness(
+  candidates: RestBuildCandidate[],
+  traDuration?: number,
+  traStartedAtMs?: number,
+): RestBuildCandidate | undefined {
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  if (traStartedAtMs !== undefined) {
+    const withTime = candidates.filter((c) => c.startedAtMs !== undefined);
+    if (withTime.length === candidates.length) {
+      const ranked = [...withTime].sort(
+        (a, b) =>
+          Math.abs((a.startedAtMs as number) - traStartedAtMs) -
+          Math.abs((b.startedAtMs as number) - traStartedAtMs),
+      );
+      const best = ranked[0];
+      const bestDelta = Math.abs((best.startedAtMs as number) - traStartedAtMs);
+      const tied = ranked.filter(
+        (c) =>
+          Math.abs((c.startedAtMs as number) - traStartedAtMs) === bestDelta,
+      );
+      if (tied.length === 1) {
+        return tied[0];
+      }
+    }
+  }
+
+  if (traDuration !== undefined) {
+    const withDuration = candidates.filter((c) => c.duration !== undefined);
+    if (withDuration.length === candidates.length) {
+      const ranked = [...withDuration].sort(
+        (a, b) =>
+          Math.abs((a.duration as number) - traDuration) -
+          Math.abs((b.duration as number) - traDuration),
+      );
+      const best = ranked[0];
+      const bestDelta = Math.abs((best.duration as number) - traDuration);
+      const tied = ranked.filter(
+        (c) => Math.abs((c.duration as number) - traDuration) === bestDelta,
+      );
+      if (tied.length === 1) {
+        return tied[0];
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function formatCandidates(candidates: RestBuildCandidate[]): string {
+  return candidates.map((c) => `${c.hashedId} (${c.sessionType})`).join(", ");
+}
+
+async function fetchTraBuild(
+  observabilityId: string,
+  config: BrowserStackConfig,
+): Promise<TraBuildPayload> {
+  const response = await apiClient.get({
+    url: `https://api-automation.browserstack.com/ext/v1/builds/${encodeURIComponent(observabilityId)}`,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: authHeader(config),
+    },
+    raise_error: false,
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(
+        `Observability build "${observabilityId}" was not found. ` +
+          "Use the UUID from getBuildId / listBuildId / fetchBuildInsights " +
+          "(or an observability dashboard URL), not a hashed Automate dashboard build ID.",
+      );
+    }
+    throw new Error(
+      `Failed to fetch observability build: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return (response.data ?? {}) as TraBuildPayload;
+}
+
+async function listRestBuilds(
+  sessionType: SessionType,
+  config: BrowserStackConfig,
+): Promise<RestBuildCandidate[]> {
+  const candidates: RestBuildCandidate[] = [];
+  let offset = 0;
+
+  while (candidates.length < BUILD_LIST_MAX_BUILDS) {
+    const remaining = BUILD_LIST_MAX_BUILDS - candidates.length;
+    const limit = Math.min(BUILD_LIST_PAGE_SIZE, remaining);
+    const response = await apiClient.get({
+      url: buildsListUrl(sessionType),
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: authHeader(config),
+      },
+      params: { limit, offset },
+      raise_error: false,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to list ${sessionType} builds: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const items = Array.isArray(response.data) ? response.data : [];
+    if (items.length === 0) {
+      break;
+    }
+
+    for (const item of items as BuildListItem[]) {
+      const build = item.automation_build;
+      if (!build) {
+        continue;
+      }
+      const hashedId = build.hashed_id?.trim();
+      const name = build.name?.trim();
+      if (!hashedId || !name) {
+        continue;
+      }
+      candidates.push({
+        hashedId,
+        name,
+        sessionType,
+        duration:
+          typeof build.duration === "number" ? build.duration : undefined,
+        startedAtMs: parseTimestampMs(build.started_at ?? build.created_at),
+      });
+    }
+
+    if (items.length < limit) {
+      break;
+    }
+    offset += items.length;
+  }
+
+  return candidates;
+}
+
+function selectByName(
+  candidates: RestBuildCandidate[],
+  originalName?: string,
+  derivedName?: string,
+  traDuration?: number,
+  traStartedAtMs?: number,
+): RestBuildCandidate {
+  const originalMatches = originalName
+    ? candidates.filter((c) => matchKind(c.name, originalName, undefined))
+    : [];
+  const nameMatches = derivedName
+    ? candidates.filter((c) => matchKind(c.name, undefined, derivedName))
+    : [];
+  const matches = originalMatches.length > 0 ? originalMatches : nameMatches;
+
+  if (matches.length === 0) {
+    throw new Error(
+      `No Automate/App Automate hashed build ID matched observability build ` +
+        `"${originalName ?? derivedName ?? "unknown"}".`,
+    );
+  }
+
+  const products = new Set(matches.map((c) => c.sessionType));
+  if (products.size > 1) {
+    throw new Error(
+      "Matched the same build name in both automate and app-automate. " +
+        `Pass sessionType to disambiguate. Candidates: ${formatCandidates(matches)}`,
+    );
+  }
+
+  const picked = pickByCloseness(matches, traDuration, traStartedAtMs);
+  if (!picked) {
+    throw new Error(
+      `Multiple hashed builds share this name. Candidates: ${formatCandidates(matches)}`,
+    );
+  }
+  return picked;
+}
+
+export async function resolveHashedBuildId(
+  args: ResolveHashedBuildIdArgs,
+  config: BrowserStackConfig,
+): Promise<ResolvedHashedBuildId> {
+  const observabilityId = parseObservabilityId(args.observabilityId);
+  const tra = await fetchTraBuild(observabilityId, config);
+  const directHashedId = extractDirectHashedId(tra);
+  const products = productsToSearch(args.sessionType);
+
+  const listed: RestBuildCandidate[] = [];
+  for (const product of products) {
+    listed.push(...(await listRestBuilds(product, config)));
+  }
+
+  if (directHashedId) {
+    const byHash = listed.filter((c) => c.hashedId === directHashedId);
+    if (byHash.length === 1) {
+      return {
+        hashedBuildId: directHashedId,
+        sessionType: byHash[0].sessionType,
+        name: byHash[0].name || tra.original_name || tra.name || "",
+        observabilityId,
+      };
+    }
+    if (byHash.length > 1) {
+      const productsFound = new Set(byHash.map((c) => c.sessionType));
+      if (productsFound.size > 1) {
+        throw new Error(
+          "Hashed build ID appears in both automate and app-automate. " +
+            `Pass sessionType to disambiguate. Candidates: ${formatCandidates(byHash)}`,
+        );
+      }
+      return {
+        hashedBuildId: directHashedId,
+        sessionType: byHash[0].sessionType,
+        name: byHash[0].name || tra.original_name || tra.name || "",
+        observabilityId,
+      };
+    }
+    if (args.sessionType) {
+      return {
+        hashedBuildId: directHashedId,
+        sessionType: args.sessionType,
+        name: tra.original_name || tra.name || "",
+        observabilityId,
+      };
+    }
+  }
+
+  const selected = selectByName(
+    listed,
+    tra.original_name,
+    tra.name,
+    typeof tra.duration === "number" ? tra.duration : undefined,
+    parseTimestampMs(tra.started_at),
+  );
+
+  return {
+    hashedBuildId: selected.hashedId,
+    sessionType: selected.sessionType,
+    name: selected.name,
+    observabilityId,
+  };
+}

--- a/src/tools/automate.ts
+++ b/src/tools/automate.ts
@@ -2,6 +2,10 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { fetchAutomationScreenshots } from "./automate-utils/fetch-screenshots.js";
+import {
+  DEFAULT_SESSION_LIST_LIMIT,
+  listSessionIds,
+} from "./automate-utils/list-session-ids.js";
 import { SessionType } from "../lib/constants.js";
 import { trackMCP } from "../lib/instrumentation.js";
 import logger from "../logger.js";
@@ -66,6 +70,53 @@ export async function fetchAutomationScreenshotsTool(
   }
 }
 
+export async function listSessionIdsTool(
+  args: {
+    sessionType: SessionType;
+    buildId: string;
+    limit?: number;
+    offset?: number;
+    status?: string;
+  },
+  config: BrowserStackConfig,
+): Promise<CallToolResult> {
+  try {
+    const sessions = await listSessionIds(args, config);
+    if (sessions.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "No sessions found for this hashed build ID.",
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(sessions, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    logger.error("Error listing session IDs", error);
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error listing session IDs: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
 //Registers the fetchAutomationScreenshots tool with the MCP server
 export default function addAutomationTools(
   server: McpServer,
@@ -114,6 +165,85 @@ export default function addAutomationTools(
             {
               type: "text",
               text: `Error during fetching automate screenshots: ${errorMessage}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  tools.listSessionIds = server.tool(
+    "listSessionIds",
+    "List Automate/App Automate session hashed IDs for a REST hashed build ID. " +
+      "Use the dashboard hashed build id (same family as App Automate " +
+      "getFailureLogs buildId). If you only have an observability UUID from " +
+      "getBuildId or listBuildId, call fetchBuildInsights and use hashed_id " +
+      "when present. Returned sessionId values work with getFailureLogs, " +
+      "fetchAutomationScreenshots, and fetchSelfHealedSelectors.",
+    {
+      sessionType: z
+        .enum([SessionType.Automate, SessionType.AppAutomate])
+        .describe("Type of BrowserStack session"),
+      buildId: z
+        .string()
+        .describe(
+          "REST hashed Automate/App Automate build ID from the dashboard URL " +
+            "or hashed_id from fetchBuildInsights (not the observability UUID " +
+            "from getBuildId / listBuildId). Same ID family as App Automate " +
+            "getFailureLogs buildId.",
+        ),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          `Max sessions to return. Defaults to ${DEFAULT_SESSION_LIST_LIMIT}.`,
+        ),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe("Pagination offset for the REST session list."),
+      status: z
+        .string()
+        .optional()
+        .describe(
+          "Optional session status filter (e.g. done, running, error). Applied client-side.",
+        ),
+    },
+    {
+      title: "List Session IDs",
+      readOnlyHint: true,
+      openWorldHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    async (args) => {
+      try {
+        trackMCP(
+          "listSessionIds",
+          server.server.getClientVersion()!,
+          undefined,
+          config,
+        );
+        return await listSessionIdsTool(args, config);
+      } catch (error) {
+        trackMCP(
+          "listSessionIds",
+          server.server.getClientVersion()!,
+          error,
+          config,
+        );
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error listing session IDs: ${errorMessage}`,
             },
           ],
           isError: true,

--- a/src/tools/automate.ts
+++ b/src/tools/automate.ts
@@ -173,13 +173,14 @@ export default function addAutomationTools(
     },
   );
 
-  tools.listSessionIds = server.tool(
-    "listSessionIds",
-    "List Automate/App Automate session hashed IDs for a REST hashed build ID. " +
-      "Use the dashboard hashed build id (same family as App Automate " +
-      "getFailureLogs buildId). If you only have an observability UUID from " +
-      "getBuildId or listBuildId, call fetchBuildInsights and use hashed_id " +
-      "when present. Returned sessionId values work with getFailureLogs, " +
+  tools.listSessions = server.tool(
+    "listSessions",
+    "List Automate/App Automate sessions for a hashed build ID, including " +
+      "hashed session IDs and session details (name, status, OS, browser/device, " +
+      "and dashboard URL). Use the dashboard hashed build id (same family as " +
+      "App Automate getFailureLogs buildId). If you only have an observability " +
+      "UUID from getBuildId or listBuildId, call fetchBuildInsights and use " +
+      "hashed_id when present. Returned sessionId values work with getFailureLogs, " +
       "fetchAutomationScreenshots, and fetchSelfHealedSelectors.",
     {
       sessionType: z
@@ -215,7 +216,7 @@ export default function addAutomationTools(
         ),
     },
     {
-      title: "List Session IDs",
+      title: "List Sessions",
       readOnlyHint: true,
       openWorldHint: false,
       destructiveHint: false,
@@ -224,7 +225,7 @@ export default function addAutomationTools(
     async (args) => {
       try {
         trackMCP(
-          "listSessionIds",
+          "listSessions",
           server.server.getClientVersion()!,
           undefined,
           config,
@@ -232,7 +233,7 @@ export default function addAutomationTools(
         return await listSessionIdsTool(args, config);
       } catch (error) {
         trackMCP(
-          "listSessionIds",
+          "listSessions",
           server.server.getClientVersion()!,
           error,
           config,

--- a/src/tools/build-insights.ts
+++ b/src/tools/build-insights.ts
@@ -115,7 +115,7 @@ export default function addBuildInsightsTools(
 
   tools.fetchBuildInsights = server.tool(
     "fetchBuildInsights",
-    "Fetches insights about a BrowserStack build by combining build details and quality gate results. The insights JSON includes hashed_id (the Automate/App Automate REST build id used by listSessionIds) when it can be resolved from observability or Automate REST.",
+    "Fetches insights about a BrowserStack build by combining build details and quality gate results. The insights JSON includes hashed_id (the Automate/App Automate build id used by listSessions)",
     {
       buildId: z.string().describe("The build UUID of the BrowserStack build"),
     },

--- a/src/tools/build-insights.ts
+++ b/src/tools/build-insights.ts
@@ -5,6 +5,10 @@ import logger from "../logger.js";
 import { BrowserStackConfig } from "../lib/types.js";
 import { fetchFromBrowserStackAPI, handleMCPError } from "../lib/utils.js";
 import { trackMCP } from "../lib/instrumentation.js";
+import {
+  extractDirectHashedId,
+  resolveHashedBuildId,
+} from "./automate-utils/resolve-hashed-build-id.js";
 
 // Tool function that fetches build insights from two APIs
 export async function fetchBuildInsightsTool(
@@ -19,6 +23,12 @@ export async function fetchBuildInsightsTool(
       fetchFromBrowserStackAPI(buildUrl, config),
       fetchFromBrowserStackAPI(qualityGateUrl, config),
     ]);
+
+    const hashed_id = await resolveInsightsHashedId(
+      args.buildId,
+      buildData,
+      config,
+    );
 
     // Select useful fields for users
     const insights = {
@@ -35,6 +45,7 @@ export async function fetchBuildInsightsTool(
       observability_url: buildData?.observability_url,
       ci_build_url: buildData.ci_info?.build_url,
       quality_gate_result: qualityData.quality_gate_result,
+      ...(hashed_id ? { hashed_id } : {}),
     };
 
     const qualityProfiles = qualityData.quality_profiles?.map(
@@ -64,6 +75,30 @@ export async function fetchBuildInsightsTool(
   }
 }
 
+async function resolveInsightsHashedId(
+  observabilityId: string,
+  buildData: unknown,
+  config: BrowserStackConfig,
+): Promise<string | undefined> {
+  const direct = extractDirectHashedId(
+    (buildData ?? {}) as Parameters<typeof extractDirectHashedId>[0],
+  );
+  if (direct) {
+    return direct;
+  }
+
+  try {
+    const resolved = await resolveHashedBuildId({ observabilityId }, config);
+    return resolved.hashedBuildId;
+  } catch (error) {
+    logger.error(
+      "Could not resolve Automate hashed_id for build insights",
+      error,
+    );
+    return undefined;
+  }
+}
+
 // Registers the fetchBuildInsights tool with the MCP server
 export default function addBuildInsightsTools(
   server: McpServer,
@@ -73,7 +108,7 @@ export default function addBuildInsightsTools(
 
   tools.fetchBuildInsights = server.tool(
     "fetchBuildInsights",
-    "Fetches insights about a BrowserStack build by combining build details and quality gate results.",
+    "Fetches insights about a BrowserStack build by combining build details and quality gate results. The insights JSON includes hashed_id (the Automate/App Automate REST build id used by listSessionIds) when it can be resolved from observability or Automate REST.",
     {
       buildId: z.string().describe("The build UUID of the BrowserStack build"),
     },

--- a/tests/tools/buildInsights.test.ts
+++ b/tests/tools/buildInsights.test.ts
@@ -1,11 +1,26 @@
 import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
 import { fetchBuildInsightsTool } from "../../src/tools/build-insights";
 import { fetchFromBrowserStackAPI } from "../../src/lib/utils";
+import { resolveHashedBuildId } from "../../src/tools/automate-utils/resolve-hashed-build-id";
+import { SessionType } from "../../src/lib/constants";
 
 vi.mock("../../src/lib/utils", () => ({
   fetchFromBrowserStackAPI: vi.fn(),
   handleMCPError: vi.fn(),
 }));
+vi.mock(
+  "../../src/tools/automate-utils/resolve-hashed-build-id",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../src/tools/automate-utils/resolve-hashed-build-id")
+      >();
+    return {
+      ...actual,
+      resolveHashedBuildId: vi.fn(),
+    };
+  },
+);
 vi.mock("../../src/logger", () => ({
   default: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
@@ -16,8 +31,13 @@ const mockConfig = {
   "browserstack-access-key": "fake-key",
 };
 
+const HASHED_ID = "ca9cccc228cf0e3ff3cb90dd62e2e2bfb4b20bc7";
+
 describe("fetchBuildInsightsTool", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (resolveHashedBuildId as Mock).mockRejectedValue(new Error("no hashed id"));
+  });
 
   it("SUCCESS: returns build details and quality gates", async () => {
     (fetchFromBrowserStackAPI as Mock)
@@ -48,7 +68,48 @@ describe("fetchBuildInsightsTool", () => {
     expect(result.content.length).toBe(2);
     expect(result.content[0].text).toContain("Build insights");
     expect(result.content[0].text).toContain("Test Build");
+    expect(result.content[0].text).not.toContain("hashed_id");
     expect(result.content[1].text).toContain("Quality Gate Profiles");
+  });
+
+  it("SUCCESS: includes hashed_id when TRA returns a 40-char hex id", async () => {
+    (fetchFromBrowserStackAPI as Mock)
+      .mockResolvedValueOnce({
+        name: "Test Build",
+        hashed_id: HASHED_ID,
+      })
+      .mockResolvedValueOnce({});
+
+    const result = await fetchBuildInsightsTool(
+      { buildId: "build-123" },
+      mockConfig,
+    );
+
+    expect(result.content[0].text).toContain(`"hashed_id": "${HASHED_ID}"`);
+    expect(resolveHashedBuildId).not.toHaveBeenCalled();
+  });
+
+  it("SUCCESS: includes hashed_id from Automate REST when TRA omits it", async () => {
+    (fetchFromBrowserStackAPI as Mock)
+      .mockResolvedValueOnce({ name: "Test Build" })
+      .mockResolvedValueOnce({});
+    (resolveHashedBuildId as Mock).mockResolvedValue({
+      hashedBuildId: HASHED_ID,
+      sessionType: SessionType.Automate,
+      name: "Test Build",
+      observabilityId: "build-123",
+    });
+
+    const result = await fetchBuildInsightsTool(
+      { buildId: "build-123" },
+      mockConfig,
+    );
+
+    expect(result.content[0].text).toContain(`"hashed_id": "${HASHED_ID}"`);
+    expect(resolveHashedBuildId).toHaveBeenCalledWith(
+      { observabilityId: "build-123" },
+      mockConfig,
+    );
   });
 
   it("SUCCESS: handles missing quality gates data", async () => {

--- a/tests/tools/list-session-ids.test.ts
+++ b/tests/tools/list-session-ids.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import { SessionType } from "../../src/lib/constants";
+import { apiClient } from "../../src/lib/apiClient";
+import {
+  DEFAULT_SESSION_LIST_LIMIT,
+  listSessionIds,
+  mapSessionRecords,
+  sessionsListUrl,
+} from "../../src/tools/automate-utils/list-session-ids";
+import { listSessionIdsTool } from "../../src/tools/automate";
+
+vi.mock("../../src/lib/apiClient", () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+vi.mock("../../src/logger", () => ({
+  default: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("../../src/lib/instrumentation", () => ({ trackMCP: vi.fn() }));
+
+const mockConfig = {
+  "browserstack-username": "fake-user",
+  "browserstack-access-key": "fake-key",
+};
+
+const samplePayload = [
+  {
+    automation_session: {
+      name: "pricing_session",
+      status: "done",
+      hashed_id: "sess-aaa",
+      os: "Windows",
+      os_version: "11",
+      browser: "chrome",
+      device: null,
+      browser_url: "https://automate.browserstack.com/sessions/sess-aaa",
+    },
+  },
+  {
+    automation_session: {
+      name: "other",
+      status: "running",
+      hashed_id: "sess-bbb",
+      os: "OS X",
+      os_version: "Sonoma",
+      browser: "firefox",
+      device: null,
+      browser_url: "https://automate.browserstack.com/sessions/sess-bbb",
+    },
+  },
+];
+
+describe("sessionsListUrl", () => {
+  it("uses Automate REST host for automate", () => {
+    expect(sessionsListUrl(SessionType.Automate, "build-1")).toBe(
+      "https://api.browserstack.com/automate/builds/build-1/sessions.json",
+    );
+  });
+
+  it("uses App Automate api-cloud host", () => {
+    expect(sessionsListUrl(SessionType.AppAutomate, "build-1")).toBe(
+      "https://api-cloud.browserstack.com/app-automate/builds/build-1/sessions.json",
+    );
+  });
+
+  it("encodes the hashed build id", () => {
+    expect(sessionsListUrl(SessionType.Automate, "a/b")).toContain(
+      "builds/a%2Fb/sessions.json",
+    );
+  });
+});
+
+describe("mapSessionRecords", () => {
+  it("maps hashed_id to sessionId and compact fields", () => {
+    expect(mapSessionRecords(samplePayload)).toEqual([
+      {
+        sessionId: "sess-aaa",
+        name: "pricing_session",
+        status: "done",
+        os: "Windows",
+        osVersion: "11",
+        browser: "chrome",
+        device: null,
+        browserUrl: "https://automate.browserstack.com/sessions/sess-aaa",
+      },
+      {
+        sessionId: "sess-bbb",
+        name: "other",
+        status: "running",
+        os: "OS X",
+        osVersion: "Sonoma",
+        browser: "firefox",
+        device: null,
+        browserUrl: "https://automate.browserstack.com/sessions/sess-bbb",
+      },
+    ]);
+  });
+
+  it("skips items without hashed_id", () => {
+    expect(
+      mapSessionRecords([{ automation_session: { name: "no-id" } }]),
+    ).toEqual([]);
+  });
+
+  it("filters by status client-side (case-insensitive)", () => {
+    expect(mapSessionRecords(samplePayload, "DONE")).toEqual([
+      expect.objectContaining({ sessionId: "sess-aaa", status: "done" }),
+    ]);
+  });
+
+  it("returns empty array for non-array payloads", () => {
+    expect(mapSessionRecords({ error: "nope" })).toEqual([]);
+  });
+});
+
+describe("listSessionIds", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches Automate sessions with default limit", async () => {
+    (apiClient.get as Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: samplePayload,
+    });
+
+    const result = await listSessionIds(
+      { sessionType: SessionType.Automate, buildId: " hashed-build " },
+      mockConfig,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.browserstack.com/automate/builds/hashed-build/sessions.json",
+        params: { limit: DEFAULT_SESSION_LIST_LIMIT },
+        raise_error: false,
+      }),
+    );
+  });
+
+  it("passes limit and offset and uses App Automate URL", async () => {
+    (apiClient.get as Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: [],
+    });
+
+    await listSessionIds(
+      {
+        sessionType: SessionType.AppAutomate,
+        buildId: "app-build",
+        limit: 2,
+        offset: 4,
+      },
+      mockConfig,
+    );
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api-cloud.browserstack.com/app-automate/builds/app-build/sessions.json",
+        params: { limit: 2, offset: 4 },
+      }),
+    );
+  });
+
+  it("throws a hashed-build-id message on 404", async () => {
+    (apiClient.get as Mock).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      data: {},
+    });
+
+    await expect(
+      listSessionIds(
+        { sessionType: SessionType.Automate, buildId: "bad" },
+        mockConfig,
+      ),
+    ).rejects.toThrow(/Invalid hashed build ID/);
+  });
+
+  it("throws on other HTTP errors", async () => {
+    (apiClient.get as Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      data: {},
+    });
+
+    await expect(
+      listSessionIds(
+        { sessionType: SessionType.Automate, buildId: "x" },
+        mockConfig,
+      ),
+    ).rejects.toThrow(/Failed to list sessions: 500/);
+  });
+});
+
+describe("listSessionIdsTool", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns compact JSON session records", async () => {
+    (apiClient.get as Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: samplePayload,
+    });
+
+    const result = await listSessionIdsTool(
+      { sessionType: SessionType.Automate, buildId: "hashed-build" },
+      mockConfig,
+    );
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content[0].text as string);
+    expect(parsed[0].sessionId).toBe("sess-aaa");
+  });
+
+  it("returns success with a note when the list is empty", async () => {
+    (apiClient.get as Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: [],
+    });
+
+    const result = await listSessionIdsTool(
+      { sessionType: SessionType.Automate, buildId: "hashed-build" },
+      mockConfig,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain("No sessions found");
+  });
+
+  it("returns isError on API failure", async () => {
+    (apiClient.get as Mock).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      data: {},
+    });
+
+    const result = await listSessionIdsTool(
+      { sessionType: SessionType.Automate, buildId: "bad" },
+      mockConfig,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Error listing session IDs");
+  });
+});

--- a/tests/tools/resolve-hashed-build-id.test.ts
+++ b/tests/tools/resolve-hashed-build-id.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import { SessionType } from "../../src/lib/constants";
+import { apiClient } from "../../src/lib/apiClient";
+import {
+  BUILD_LIST_PAGE_SIZE,
+  buildsListUrl,
+  parseObservabilityId,
+  resolveHashedBuildId,
+} from "../../src/tools/automate-utils/resolve-hashed-build-id";
+
+vi.mock("../../src/lib/apiClient", () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+vi.mock("../../src/logger", () => ({
+  default: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("../../src/lib/instrumentation", () => ({ trackMCP: vi.fn() }));
+
+const mockConfig = {
+  "browserstack-username": "fake-user",
+  "browserstack-access-key": "fake-key",
+};
+
+const OBS_ID = "81yobvicuiuozd1bncaeegvubey7rbl8naevwets";
+const HASHED_A = "ca9cccc228cf0e3ff3cb90dd62e2e2bfb4b20bc7";
+const HASHED_B = "3b20f82b878c120e6edc7a2b373e65d20fb3ab7c";
+const HASHED_APP = "e8cde62c7e261edb013e82ac0096a650b4694b84";
+
+function traOk(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    data: {
+      name: "wdio-cucumber-samples",
+      original_name: "wdio-cucumber-samples",
+      duration: 254005,
+      started_at: "2024-05-08T12:45:34.651+00:00",
+      ...overrides,
+    },
+  };
+}
+
+function restBuilds(
+  items: Array<{ name: string; hashed_id: string; duration?: number }>,
+) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    data: items.map((item) => ({
+      automation_build: item,
+    })),
+  };
+}
+
+describe("parseObservabilityId", () => {
+  it("trims a bare UUID", () => {
+    expect(parseObservabilityId(`  ${OBS_ID}  `)).toBe(OBS_ID);
+  });
+
+  it("takes the last path segment from a dashboard URL", () => {
+    expect(
+      parseObservabilityId(
+        `https://observability.browserstack.com/builds/${OBS_ID}`,
+      ),
+    ).toBe(OBS_ID);
+  });
+
+  it("throws when empty", () => {
+    expect(() => parseObservabilityId("   ")).toThrow(
+      /Observability ID is required/,
+    );
+  });
+});
+
+describe("buildsListUrl", () => {
+  it("uses Automate REST host", () => {
+    expect(buildsListUrl(SessionType.Automate)).toBe(
+      "https://api.browserstack.com/automate/builds.json",
+    );
+  });
+
+  it("uses App Automate api-cloud host", () => {
+    expect(buildsListUrl(SessionType.AppAutomate)).toBe(
+      "https://api-cloud.browserstack.com/app-automate/builds.json",
+    );
+  });
+});
+
+describe("resolveHashedBuildId", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws a TRA 404 that distinguishes observability UUID from hashed dashboard ID", async () => {
+    (apiClient.get as Mock).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      data: {},
+    });
+
+    await expect(
+      resolveHashedBuildId({ observabilityId: OBS_ID }, mockConfig),
+    ).rejects.toThrow(/not a hashed Automate dashboard build ID/);
+  });
+
+  it("returns a direct hashed_id from the TRA payload", async () => {
+    (apiClient.get as Mock)
+      .mockResolvedValueOnce(traOk({ hashed_id: HASHED_A }))
+      .mockResolvedValueOnce(
+        restBuilds([{ name: "other", hashed_id: HASHED_B }]),
+      )
+      .mockResolvedValueOnce(
+        restBuilds([{ name: "wdio-cucumber-samples", hashed_id: HASHED_A }]),
+      );
+
+    const result = await resolveHashedBuildId(
+      { observabilityId: ` ${OBS_ID} ` },
+      mockConfig,
+    );
+
+    expect(result).toEqual({
+      hashedBuildId: HASHED_A,
+      sessionType: SessionType.AppAutomate,
+      name: "wdio-cucumber-samples",
+      observabilityId: OBS_ID,
+    });
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: `https://api-automation.browserstack.com/ext/v1/builds/${OBS_ID}`,
+      }),
+    );
+  });
+
+  it("matches Automate REST builds by original_name", async () => {
+    (apiClient.get as Mock).mockImplementation(
+      async ({ url }: { url: string }) => {
+        if (url.includes("/ext/v1/builds/")) {
+          return traOk();
+        }
+        if (url.includes("/automate/builds.json")) {
+          return restBuilds([
+            {
+              name: "wdio-cucumber-samples",
+              hashed_id: HASHED_A,
+              duration: 254005,
+            },
+          ]);
+        }
+        if (url.includes("/app-automate/builds.json")) {
+          return restBuilds([]);
+        }
+        throw new Error(`unexpected url ${url}`);
+      },
+    );
+
+    const result = await resolveHashedBuildId(
+      {
+        observabilityId: `https://observability.browserstack.com/x/${OBS_ID}`,
+      },
+      mockConfig,
+    );
+
+    expect(result.hashedBuildId).toBe(HASHED_A);
+    expect(result.sessionType).toBe(SessionType.Automate);
+    expect(result.name).toBe("wdio-cucumber-samples");
+    expect(result.observabilityId).toBe(OBS_ID);
+  });
+
+  it("matches Automate REST names that append a whitespace suffix", async () => {
+    (apiClient.get as Mock).mockImplementation(
+      async ({ url }: { url: string }) => {
+        if (url.includes("/ext/v1/builds/")) {
+          return traOk({
+            original_name:
+              "jenkins-dev-devx-developer-portal-pages-developer-portal-pages-PR-6992-15",
+            name: "jenkins-dev-devx-developer-portal-pages-developer-portal-pages-PR",
+          });
+        }
+        if (url.includes("/automate/builds.json")) {
+          return restBuilds([
+            {
+              name: "jenkins-dev-devx-developer-portal-pages-developer-portal-pages-PR-6992-15  15",
+              hashed_id: HASHED_A,
+            },
+          ]);
+        }
+        return restBuilds([]);
+      },
+    );
+
+    const result = await resolveHashedBuildId(
+      { observabilityId: OBS_ID },
+      mockConfig,
+    );
+
+    expect(result.hashedBuildId).toBe(HASHED_A);
+  });
+
+  it("searches only App Automate when sessionType is set", async () => {
+    (apiClient.get as Mock).mockImplementation(
+      async ({ url }: { url: string }) => {
+        if (url.includes("/ext/v1/builds/")) {
+          return traOk();
+        }
+        if (url.includes("/app-automate/builds.json")) {
+          return restBuilds([
+            { name: "wdio-cucumber-samples", hashed_id: HASHED_APP },
+          ]);
+        }
+        throw new Error(`should not call ${url}`);
+      },
+    );
+
+    const result = await resolveHashedBuildId(
+      { observabilityId: OBS_ID, sessionType: SessionType.AppAutomate },
+      mockConfig,
+    );
+
+    expect(result.hashedBuildId).toBe(HASHED_APP);
+    expect(result.sessionType).toBe(SessionType.AppAutomate);
+    expect(apiClient.get).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.browserstack.com/automate/builds.json",
+      }),
+    );
+  });
+
+  it("errors when both products match the same name", async () => {
+    (apiClient.get as Mock).mockImplementation(
+      async ({ url }: { url: string }) => {
+        if (url.includes("/ext/v1/builds/")) {
+          return traOk();
+        }
+        if (url.includes("/automate/builds.json")) {
+          return restBuilds([
+            { name: "wdio-cucumber-samples", hashed_id: HASHED_A },
+          ]);
+        }
+        return restBuilds([
+          { name: "wdio-cucumber-samples", hashed_id: HASHED_APP },
+        ]);
+      },
+    );
+
+    await expect(
+      resolveHashedBuildId({ observabilityId: OBS_ID }, mockConfig),
+    ).rejects.toThrow(/sessionType/);
+  });
+
+  it("picks the closer duration when multiple same-name builds exist", async () => {
+    (apiClient.get as Mock).mockImplementation(
+      async ({ url }: { url: string }) => {
+        if (url.includes("/ext/v1/builds/")) {
+          return traOk({ duration: 100 });
+        }
+        if (url.includes("/automate/builds.json")) {
+          return restBuilds([
+            {
+              name: "wdio-cucumber-samples",
+              hashed_id: HASHED_A,
+              duration: 10,
+            },
+            {
+              name: "wdio-cucumber-samples",
+              hashed_id: HASHED_B,
+              duration: 102,
+            },
+          ]);
+        }
+        return restBuilds([]);
+      },
+    );
+
+    const result = await resolveHashedBuildId(
+      { observabilityId: OBS_ID },
+      mockConfig,
+    );
+    expect(result.hashedBuildId).toBe(HASHED_B);
+  });
+
+  it("errors when same-name matches stay ambiguous", async () => {
+    (apiClient.get as Mock).mockImplementation(
+      async ({ url }: { url: string }) => {
+        if (url.includes("/ext/v1/builds/")) {
+          return traOk({ duration: undefined, started_at: undefined });
+        }
+        if (url.includes("/automate/builds.json")) {
+          return restBuilds([
+            { name: "wdio-cucumber-samples", hashed_id: HASHED_A },
+            { name: "wdio-cucumber-samples", hashed_id: HASHED_B },
+          ]);
+        }
+        return restBuilds([]);
+      },
+    );
+
+    await expect(
+      resolveHashedBuildId({ observabilityId: OBS_ID }, mockConfig),
+    ).rejects.toThrow(new RegExp(`${HASHED_A}|${HASHED_B}`));
+  });
+
+  it("paginates REST build lists", async () => {
+    const page1 = Array.from({ length: BUILD_LIST_PAGE_SIZE }, (_, i) => ({
+      name: `other-${i}`,
+      hashed_id:
+        `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa${i.toString(16)}`.slice(0, 40),
+    }));
+
+    (apiClient.get as Mock).mockImplementation(
+      async ({
+        url,
+        params,
+      }: {
+        url: string;
+        params?: { offset?: number };
+      }) => {
+        if (url.includes("/ext/v1/builds/")) {
+          return traOk();
+        }
+        if (url.includes("/automate/builds.json")) {
+          if (!params?.offset) {
+            return restBuilds(page1);
+          }
+          return restBuilds([
+            { name: "wdio-cucumber-samples", hashed_id: HASHED_A },
+          ]);
+        }
+        return restBuilds([]);
+      },
+    );
+
+    const result = await resolveHashedBuildId(
+      { observabilityId: OBS_ID, sessionType: SessionType.Automate },
+      mockConfig,
+    );
+    expect(result.hashedBuildId).toBe(HASHED_A);
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.browserstack.com/automate/builds.json",
+        params: { limit: BUILD_LIST_PAGE_SIZE, offset: BUILD_LIST_PAGE_SIZE },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Agents can now walk from an observability build ID to Automate session data including IDs and then to failure logs.
Sample prompt: `Get failures logs for build <build id>`
Traversal:
- `fetchBuildInsights` — resolve observability UUID to `hashed_id` when present
- `listSessions` — list Automate/App Automate session IDs for that hashed build ID
- `getFailureLogs` — fetch logs for those session IDs

There previously wasn't a way for agents to call `getFailureLogs` for a given test run because it required sessions Ids and there wasn't a way to fetch session ids for a given test run. This additional tool call allows for that traversal. 

## Test plan
- [x] Unit tests
- [x] Tested with Cursor