### PR TITLE
feat(loadtesting): declare the HTTP Basic auth scheme in the index

### DIFF
--- a/capability/loadtesting.capability-index.json
+++ b/capability/loadtesting.capability-index.json
@@ -5,6 +5,10 @@
   "loadtesting": {
     "summary": "Load and performance testing: run k6, JMeter, Gatling and Locust load tests at scale. List and inspect projects and load tests; create, update, start, stop and monitor runs; read run reports, AI insights and historical trends; compare runs; and check VU-hour quota and cost estimates. Test definitions, runs and their results live here. Account plan and billing do not — only VU-hour entitlement is exposed, via quota.",
     "base_url": "https://load-api.browserstack.com",
+    "auth": {
+      "type": "http",
+      "scheme": "basic"
+    },
     "capabilities": [
       {
         "method": "GET",


### PR DESCRIPTION
Declares Load Testing's auth scheme so `invokeEndpoint` stops returning 401.

## Why

The server defaults to `Api-Token: <username>:<access_key>`, which every tm `/api/v1` route accepts. load-api's `/api/v1/agent/*` surface takes **HTTP Basic** instead, and until now the index had nowhere to say so — the requirement lived in #388's description while the server sent Api-Token regardless. Discovery and host resolution worked; execution did not.

## The change

```diff
   "base_url": "https://load-api.browserstack.com",
+  "auth": {
+    "type": "http",
+    "scheme": "basic"
+  },
   "capabilities": [
```

Four lines. No other field touched, key order preserved, still valid JSON with all 20 capabilities intact.

This uses the `auth` block added to the server in `f8b2278` (AIMCP-211), which follows OpenAPI's `securityScheme` vocabulary. `type: http, scheme: basic` means the caller's own credentials composed as `{username}:{access_key}` and base64-encoded into `Authorization: Basic …`. No new credential, no token minted.

## Verified

Both products resolved from their real indexes through `invoke`:

```
loadtesting: auth = {"type":"http","scheme":"basic"}
   headers: {"Authorization":"Basic dTpr"}   decoded: u:k

tm:          auth = (none -> default)
   headers: {"Api-Token":"u:k"}
```

tm is unaffected — an index without an `auth` block keeps the historical default. Full suite green (489 tests).

## One caveat for the reviewer

**The Basic requirement is taken from #388's body and has not been independently confirmed.** A search of the org finds no `agentAuth` implementation to check it against, and an empirical test is ambiguous here because the available credentials are a preprod TM account while the index points at prod load-api — a wrong scheme and a wrong account both return 401.

If someone can supply a working `curl` against `/api/v1/agent/*`, that settles it. If Basic turns out to be wrong, this is a one-line correction rather than a rethink — the mechanism is agnostic.

## Follow-up

The durable path is the harness: tm's `product.yaml` already declares `auth_schemes` with templates, and the export should forward the scheme an operation's `security` actually references. Hand-authoring it here matches how this index was created in #388.