### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserstack/mcp-server",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserstack/mcp-server",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "BrowserStack's Official MCP Server",
   "mcpName": "io.github.browserstack/mcp-server",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@browserstack/mcp-server",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What

`1.3.2 → 1.4.0`, in the three files that move in lockstep per `commit-conventions.md`:

| file | field |
|---|---|
| `package.json` | `version` |
| `package-lock.json` | `version` and `packages[""].version` |
| `server.json` | `packages[].version` |

Note `server.json`'s **top-level** `version` stays `1.0.0` — that's the server-entry schema version, not the package version. Only the entry inside `packages` tracks releases, which is how [#396](https://github.com/browserstack/mcp-server/pull/396) did it.

## Why minor, not patch

The release this unblocks adds a **new tool** (`askBrowserStackAI`) plus declared preconditions across 22 existing tools. New surface is a minor bump under semver; 1.3.x is for the patches that have been going out.

## Why this is its own PR

Review feedback on [#379](https://github.com/browserstack/mcp-server/pull/379): a version bump doesn't belong in a feature PR, and repo convention is a separate bump PR. #379 has been reverted to `1.3.2` accordingly and stays there.

## One sequencing consequence worth knowing

`1.4.0-beta.1` … `beta.3` are already published, derived from a `package.json` that said `1.4.0`. With #379 back on `1.3.2`, a Beta Release run **from that branch** would now compute `1.3.1-beta.1`/`1.3.2-beta.1` and `npm publish --tag beta` would move the `beta` dist-tag **backwards**, since it repoints unconditionally with no version-ordering check.

So: **merge this before cutting any further beta from #379.** The betas so far were published from a throwaway drop branch carrying the bumped version, precisely to avoid that.

Also for awareness: the `beta` tag currently points at `1.4.0-beta.3` (this feature), while a separate `1.5.0-beta.*` line also exists. Worth agreeing who owns `beta` before the next publish either way.

## Risk

None at runtime — three version strings, no code. `npm run build` is unaffected.
