### PR TITLE
feat(automate): add video log type and expose videoUrl in listSessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ As of now we support 45 tools.
   Get screenshots from Automate session ID abc123xyz for my desktop test run
   ```
 
- 18. `listSessions` — List the sessions in an Automate/App Automate build. Each record carries `sessionId`, `name`, `status`, `os`, `osVersion`, `browser`, `device`, and `browserUrl` (dashboard link), with optional `limit` / `offset` paging and a client-side `status` filter. Takes the **hashed** build ID from the dashboard URL — not the observability UUID returned by `getBuildId` / `listBuildId`; if you only have that UUID, use `hashed_id` from `fetchBuildInsights` when present. Returned `sessionId` values work with `getFailureLogs`, `fetchAutomationScreenshots`, and `fetchSelfHealedSelectors`.
+ 18. `listSessions` — List the sessions in an Automate/App Automate build. Each record carries `sessionId`, `name`, `status`, `os`, `osVersion`, `browser`, `device`, `browserUrl` (dashboard link), and `videoUrl`, with optional `limit` / `offset` paging and a client-side `status` filter. Takes the **hashed** build ID from the dashboard URL — not the observability UUID returned by `getBuildId` / `listBuildId`; if you only have that UUID, use `hashed_id` from `fetchBuildInsights` when present. Returned `sessionId` values work with `getFailureLogs`, `fetchAutomationScreenshots`, and `fetchSelfHealedSelectors`.
   **Prompt example**
 
   ```text
@@ -643,7 +643,7 @@ As of now we support 45 tools.
   Get the latest build ID for build 'nightly-regression' in project 'Checkout Flow'
   ```
 
- 45. `listTestIds` — List test IDs from a BrowserStack Automate build, filtered by status (passed/failed/pending/skipped).
+ 45. `listTestIds` — List the tests in a BrowserStack build (Automate or App Automate) with each test's `status` and `session_id`, optionally filtered by status (passed/failed/pending/skipped). The `session_id` feeds `getFailureLogs` and `fetchAutomationScreenshots` directly.
   **Prompt example**
 
   ```text

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,17 +2,20 @@ export const SessionType = {
   Automate: "automate",
   AppAutomate: "app-automate",
 } as const;
+export const SessionVideoLogType = "video" as const;
 
 export const AutomateLogType = {
   NetworkLogs: "networkLogs",
   SessionLogs: "sessionLogs",
   ConsoleLogs: "consoleLogs",
+  Video: SessionVideoLogType,
 } as const;
 
 export const AppAutomateLogType = {
   DeviceLogs: "deviceLogs",
   AppiumLogs: "appiumLogs",
   CrashLogs: "crashLogs",
+  Video: SessionVideoLogType,
 } as const;
 
 export type SessionType = (typeof SessionType)[keyof typeof SessionType];

--- a/src/tools/automate-utils/list-session-ids.ts
+++ b/src/tools/automate-utils/list-session-ids.ts
@@ -22,6 +22,7 @@ export interface SessionIdRecord {
   browser?: string;
   device?: string | null;
   browserUrl?: string;
+  videoUrl?: string;
 }
 
 interface AutomationSessionPayload {
@@ -33,6 +34,7 @@ interface AutomationSessionPayload {
   browser?: string;
   device?: string | null;
   browser_url?: string;
+  video_url?: string;
 }
 
 interface SessionListItem {
@@ -88,6 +90,7 @@ export function mapSessionRecords(
       browser: session.browser,
       device: session.device,
       browserUrl: session.browser_url,
+      videoUrl: session.video_url,
     });
   }
   return records;

--- a/src/tools/automate.ts
+++ b/src/tools/automate.ts
@@ -116,7 +116,7 @@ export default function addAutomationTools(
 
   tools.fetchAutomationScreenshots = server.tool(
     "fetchAutomationScreenshots",
-    "Fetch and process screenshots from a BrowserStack Automate session",
+    "Fetch screenshots captured during an Automate/App Automate session.",
     {
       sessionId: z
         .string()

--- a/src/tools/failurelogs-utils/video.ts
+++ b/src/tools/failurelogs-utils/video.ts
@@ -1,0 +1,34 @@
+import { getBrowserStackAuth } from "../../lib/get-auth.js";
+import { BrowserStackConfig } from "../../lib/types.js";
+import { apiClient } from "../../lib/apiClient.js";
+import { SessionType } from "../../lib/constants.js";
+import { validateLogResponse } from "./utils.js";
+
+export async function retrieveSessionVideo(
+  sessionId: string,
+  sessionType: SessionType,
+  config: BrowserStackConfig,
+): Promise<string> {
+  const product =
+    sessionType === SessionType.AppAutomate ? "app-automate" : "automate";
+  const url = `https://api.browserstack.com/${product}/sessions/${encodeURIComponent(sessionId)}.json`;
+  const authString = getBrowserStackAuth(config);
+  const auth = Buffer.from(authString).toString("base64");
+
+  const response = await apiClient.get({
+    url,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Basic ${auth}`,
+    },
+    raise_error: false,
+  });
+
+  const validationError = validateLogResponse(response, "session video");
+  if (validationError) return validationError.message!;
+
+  const videoUrl = (response.data as any)?.automation_session?.video_url;
+  return typeof videoUrl === "string" && videoUrl.trim()
+    ? `Session video: ${videoUrl.trim()}`
+    : "No session video available for this session";
+}

--- a/src/tools/get-failure-logs.ts
+++ b/src/tools/get-failure-logs.ts
@@ -17,11 +17,13 @@ import {
 } from "./failurelogs-utils/app-automate.js";
 
 import { resolveAppAutomateBuildId } from "./failurelogs-utils/resolve-app-build-id.js";
+import { retrieveSessionVideo } from "./failurelogs-utils/video.js";
 
 import {
   AppAutomateLogType,
   AutomateLogType,
   SessionType,
+  SessionVideoLogType,
 } from "../lib/constants.js";
 
 type LogType = AutomateLogType | AppAutomateLogType;
@@ -45,14 +47,6 @@ export async function getFailureLogs(
     throw new Error("Session ID is required");
   }
 
-  let buildId = args.buildId;
-  if (args.sessionType === SessionType.AppAutomate && !buildId) {
-    buildId = await resolveAppAutomateBuildId(args.sessionId, config);
-    if (!buildId) {
-      throw new Error("Build ID is required for app-automate sessions");
-    }
-  }
-
   // Validate log types and collect errors
   validLogTypes = args.logTypes.filter((logType) => {
     const isAutomate = Object.values(AutomateLogType).includes(
@@ -65,8 +59,10 @@ export async function getFailureLogs(
     if (!isAutomate && !isAppAutomate) {
       errors.push(
         `Invalid log type '${logType}'. Valid log types are: ${[
-          ...Object.values(AutomateLogType),
-          ...Object.values(AppAutomateLogType),
+          ...new Set([
+            ...Object.values(AutomateLogType),
+            ...Object.values(AppAutomateLogType),
+          ]),
         ].join(", ")}`,
       );
       return false;
@@ -100,11 +96,37 @@ export async function getFailureLogs(
       isError: true,
     };
   }
+
+  let buildId = args.buildId;
+  const needsBuildId = validLogTypes.some(
+    (logType) => logType !== SessionVideoLogType,
+  );
+  if (
+    args.sessionType === SessionType.AppAutomate &&
+    needsBuildId &&
+    !buildId
+  ) {
+    buildId = await resolveAppAutomateBuildId(args.sessionId, config);
+    if (!buildId) {
+      throw new Error("Build ID is required for app-automate sessions");
+    }
+  }
+
   let response;
   // eslint-disable-next-line no-useless-catch
   try {
     for (const logType of validLogTypes) {
       switch (logType) {
+        case SessionVideoLogType: {
+          response = await retrieveSessionVideo(
+            args.sessionId,
+            args.sessionType,
+            config,
+          );
+          results.push({ type: "text", text: response });
+          break;
+        }
+
         case AutomateLogType.NetworkLogs: {
           response = await retrieveNetworkFailures(args.sessionId, config);
           results.push({ type: "text", text: response });
@@ -165,7 +187,7 @@ export default function registerGetFailureLogs(
 
   tools.getFailureLogs = server.tool(
     "getFailureLogs",
-    "Fetch various types of logs from a BrowserStack session. Supports both automate and app-automate sessions.",
+    "Fetch logs, or the session video URL, for an Automate/App Automate session.",
     {
       sessionType: z
         .enum([SessionType.Automate, SessionType.AppAutomate])
@@ -192,6 +214,7 @@ export default function registerGetFailureLogs(
             AppAutomateLogType.DeviceLogs,
             AppAutomateLogType.AppiumLogs,
             AppAutomateLogType.CrashLogs,
+            SessionVideoLogType,
           ]),
         )
         .describe("The types of logs to fetch."),

--- a/tests/tools/failurelogs-video.test.ts
+++ b/tests/tools/failurelogs-video.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import { retrieveSessionVideo } from "../../src/tools/failurelogs-utils/video";
+import { apiClient } from "../../src/lib/apiClient";
+import { SessionType } from "../../src/lib/constants";
+
+vi.mock("../../src/lib/apiClient", () => ({
+  apiClient: { get: vi.fn() },
+}));
+vi.mock("../../src/lib/get-auth", () => ({
+  getBrowserStackAuth: () => "user:key",
+}));
+
+const config = {
+  "browserstack-username": "user",
+  "browserstack-access-key": "key",
+};
+const VIDEO = "https://automate.browserstack.com/sessions/abc/video?token=t";
+
+describe("retrieveSessionVideo", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the recording link for an Automate session", async () => {
+    (apiClient.get as Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: { automation_session: { video_url: VIDEO } },
+    });
+
+    await expect(
+      retrieveSessionVideo("abc", SessionType.Automate, config),
+    ).resolves.toBe(`Session video: ${VIDEO}`);
+
+    const call = (apiClient.get as Mock).mock.calls[0][0];
+    expect(call.url).toBe(
+      "https://api.browserstack.com/automate/sessions/abc.json",
+    );
+    expect(call.headers.Authorization).toBe(
+      `Basic ${Buffer.from("user:key").toString("base64")}`,
+    );
+  });
+
+  it("targets the App Automate endpoint and encodes the id", async () => {
+    (apiClient.get as Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: { automation_session: { video_url: VIDEO } },
+    });
+
+    await retrieveSessionVideo("a/b", SessionType.AppAutomate, config);
+
+    expect((apiClient.get as Mock).mock.calls[0][0].url).toBe(
+      "https://api.browserstack.com/app-automate/sessions/a%2Fb.json",
+    );
+  });
+
+  it("reports a missing session the same way the log fetchers do", async () => {
+    (apiClient.get as Mock).mockResolvedValue({ ok: false, status: 404 });
+
+    await expect(
+      retrieveSessionVideo("nope", SessionType.Automate, config),
+    ).resolves.toBe("No session video available for this session");
+  });
+
+  it("reports credential problems without leaking them", async () => {
+    (apiClient.get as Mock).mockResolvedValue({ ok: false, status: 401 });
+
+    await expect(
+      retrieveSessionVideo("abc", SessionType.Automate, config),
+    ).resolves.toMatch(/check your credentials/);
+  });
+
+  it.each([
+    ["no video_url", { automation_session: { status: "done" } }],
+    ["a blank video_url", { automation_session: { video_url: "  " } }],
+    ["no session object", {}],
+  ])("says no video is available when the payload has %s", async (_l, data) => {
+    (apiClient.get as Mock).mockResolvedValue({ ok: true, status: 200, data });
+
+    await expect(
+      retrieveSessionVideo("abc", SessionType.Automate, config),
+    ).resolves.toBe("No session video available for this session");
+  });
+});

--- a/tests/tools/getFailureLogs.test.ts
+++ b/tests/tools/getFailureLogs.test.ts
@@ -3,6 +3,7 @@ import { getFailureLogs } from '../../src/tools/get-failure-logs';
 import * as automate from '../../src/tools/failurelogs-utils/automate';
 import * as appAutomate from '../../src/tools/failurelogs-utils/app-automate';
 import { resolveAppAutomateBuildId } from '../../src/tools/failurelogs-utils/resolve-app-build-id';
+import { retrieveSessionVideo } from '../../src/tools/failurelogs-utils/video';
 
 vi.mock('../../src/config', () => ({
   __esModule: true,
@@ -18,6 +19,10 @@ vi.mock('../../src/lib/instrumentation', () => ({
 
 vi.mock('../../src/tools/failurelogs-utils/resolve-app-build-id', () => ({
   resolveAppAutomateBuildId: vi.fn(),
+}));
+
+vi.mock('../../src/tools/failurelogs-utils/video', () => ({
+  retrieveSessionVideo: vi.fn(),
 }));
 
 // Mock the utility functions with implementations
@@ -384,6 +389,58 @@ console.error('Uncaught TypeError')
       expect(appAutomate.filterDeviceFailures('')).toEqual([]);
       expect(appAutomate.filterAppiumFailures('')).toEqual([]);
       expect(appAutomate.filterCrashFailures('')).toEqual([]);
+    });
+  });
+
+  describe('Session video', () => {
+    beforeEach(() => {
+      vi.mocked(retrieveSessionVideo).mockResolvedValue('Session video: https://v/1');
+      vi.mocked(appAutomate.retrieveAppiumLogs).mockResolvedValue('Appium Failures (1 found)');
+    });
+
+    it('fetches the video for an automate session', async () => {
+      const mockServer = { server: { getClientVersion: () => "test-version" } };
+      const result = await getFailureLogs({
+        sessionId: 'sess-1',
+        logTypes: ['video'],
+        sessionType: 'automate'
+      }, mockServer);
+
+      expect(retrieveSessionVideo).toHaveBeenCalledWith('sess-1', 'automate', mockServer);
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toBe('Session video: https://v/1');
+    });
+
+    it('does not require or resolve a build id when only the video is requested for app-automate', async () => {
+      const mockServer = { server: { getClientVersion: () => "test-version" } };
+      const result = await getFailureLogs({
+        sessionId: 'sess-2',
+        logTypes: ['video'],
+        sessionType: 'app-automate'
+      }, mockServer);
+
+      expect(resolveAppAutomateBuildId).not.toHaveBeenCalled();
+      expect(retrieveSessionVideo).toHaveBeenCalledWith('sess-2', 'app-automate', mockServer);
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('resolves the build id once when video is mixed with a build-scoped log type', async () => {
+      const mockServer = { server: { getClientVersion: () => "test-version" } };
+      (resolveAppAutomateBuildId as any).mockResolvedValue('resolved-build');
+
+      const result = await getFailureLogs({
+        sessionId: 'sess-3',
+        logTypes: ['appiumLogs', 'video'],
+        sessionType: 'app-automate'
+      }, mockServer);
+
+      expect(resolveAppAutomateBuildId).toHaveBeenCalledTimes(1);
+      expect(appAutomate.retrieveAppiumLogs).toHaveBeenCalledWith('sess-3', 'resolved-build', mockServer);
+      expect(retrieveSessionVideo).toHaveBeenCalledWith('sess-3', 'app-automate', mockServer);
+      expect(result.content.map((c: any) => c.text)).toEqual([
+        'Appium Failures (1 found)',
+        'Session video: https://v/1',
+      ]);
     });
   });
 });

--- a/tests/tools/list-session-ids.test.ts
+++ b/tests/tools/list-session-ids.test.ts
@@ -35,6 +35,7 @@ const samplePayload = [
       browser: "chrome",
       device: null,
       browser_url: "https://automate.browserstack.com/sessions/sess-aaa",
+      video_url: "https://automate.browserstack.com/sessions/sess-aaa/video",
     },
   },
   {
@@ -83,6 +84,7 @@ describe("mapSessionRecords", () => {
         browser: "chrome",
         device: null,
         browserUrl: "https://automate.browserstack.com/sessions/sess-aaa",
+        videoUrl: "https://automate.browserstack.com/sessions/sess-aaa/video",
       },
       {
         sessionId: "sess-bbb",


### PR DESCRIPTION
- getFailureLogs accepts "video" in logTypes and returns the session recording URL from the Automate / App Automate session endpoint
- the App Automate build-id lookup now runs only when a build-scoped log type is requested
- listSessions carries the video_url already present on every row
- fetchAutomationScreenshots prompt covers App Automate