### PR TITLE
feat(loadtesting): accept BLU browser frameworks on createLoadTest

### DIFF
--- a/capability/loadtesting.capability-index.json
+++ b/capability/loadtesting.capability-index.json
@@ -891,11 +891,17 @@
             "name": "framework",
             "type": "string",
             "required": true,
+            "description": "PLU (protocol) frameworks: k6, jmeter, gatling, locust. BLU (browser) frameworks: playwright, selenium, webdriverio, nightwatch, lcncnightwatch. Must match testType — a PLU framework for testType plu, a BLU framework for testType blu (the backend rejects a mismatched pair).",
             "values": [
               "k6",
               "jmeter",
               "gatling",
-              "locust"
+              "locust",
+              "playwright",
+              "selenium",
+              "webdriverio",
+              "nightwatch",
+              "lcncnightwatch"
             ]
           },
           {


### PR DESCRIPTION
## Problem
`createLoadTest` accepts `testType: blu` but its `framework` enum only lists the four PLU (protocol) frameworks — `k6, jmeter, gatling, locust`. So the bind layer rejects any browser framework (`"framework must be one of: k6, jmeter, gatling, locust"`) **before the request reaches the backend**, and a BLU test cannot be created via the MCP in any project.

## Root cause is the index enum, not the backend
Verified directly against the backend (`POST /agent/loadTests`):
- `testType:blu, framework:playwright` → passes framework validation (fails only later on missing `config`).
- `testType:blu, framework:bogus` → the backend's own message: `Unknown framework "bogus". Valid PLU: JMeter, k6, locust, Gatling. Valid BLU: Playwright, Selenium, Webdriverio, Nightwatch, Lcncnightwatch.`

The backend already supports BLU create (`testTypeHelpers.js` canonicalises browser frameworks case-insensitively, by design for MCP callers). The only gate was this index enum.

## Fix
Add the five BLU frameworks to the `createLoadTest` `framework` enum (lowercase; the backend canonicaliser is case-insensitive) and document the testType↔framework pairing:

`k6, jmeter, gatling, locust, playwright, selenium, webdriverio, nightwatch, lcncnightwatch`

The backend still enforces the pairing (e.g. `blu` + `k6` is rejected server-side), so widening the enum only unblocks the valid BLU combinations. No backend change required.