### PR TITLE
docs(readme): restore listSessions observability-id wording lost in merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ As of now we support 45 tools.
   Get screenshots from Automate session ID abc123xyz for my desktop test run
   ```
 
- 18. `listSessions` — List the sessions in an Automate/App Automate build. Each record carries `sessionId`, `name`, `status`, `os`, `osVersion`, `browser`, `device`, `browserUrl` (dashboard link), and `videoUrl`, with optional `limit` / `offset` paging and a client-side `status` filter. Takes the **hashed** build ID from the dashboard URL — not the observability UUID returned by `getBuildId` / `listBuildId`; if you only have that UUID, use `hashed_id` from `fetchBuildInsights` when present. Returned `sessionId` values work with `getFailureLogs`, `fetchAutomationScreenshots`, and `fetchSelfHealedSelectors`.
+ 18. `listSessions` — List the sessions in an Automate/App Automate build. Each record carries `sessionId`, `name`, `status`, `os`, `osVersion`, `browser`, `device`, `browserUrl` (dashboard link), and `videoUrl`, with optional `limit` / `offset` paging and a client-side `status` filter. Takes either the **hashed** build ID from the dashboard URL or the observability build id returned by `getBuildId` / `listBuildId` — an observability id is resolved to the hashed id automatically via the build's sessions. Returned `sessionId` values work with `getFailureLogs`, `fetchAutomationScreenshots`, and `fetchSelfHealedSelectors`.
   **Prompt example**
 
   ```text


### PR DESCRIPTION
The main merge kept the videoUrl addition from #398 but dropped this PR's sentence saying listSessions also accepts the observability build id, so the README contradicted the tool's own describe(). Keep both.