### PR TITLE
feat(security): require MCP_UPLOAD_BASE_DIR for the upload-PRD tool

### DIFF
--- a/src/tools/testmanagement-utils/upload-file.ts
+++ b/src/tools/testmanagement-utils/upload-file.ts
@@ -43,9 +43,6 @@ export async function uploadFile(
 ): Promise<CallToolResult> {
   const { project_identifier, file_path } = args;
 
-  // File upload is opt-in: it is available only when the operator has declared
-  // an allowed directory via MCP_UPLOAD_BASE_DIR. Without it, refuse rather than
-  // allow uploads from arbitrary paths.
   if (!appConfig.UPLOAD_BASE_DIR) {
     return {
       content: [

--- a/src/tools/testmanagement-utils/upload-file.ts
+++ b/src/tools/testmanagement-utils/upload-file.ts
@@ -28,7 +28,10 @@ export const UploadFileSchema = z.object({
     ),
   file_path: z
     .string()
-    .describe("Full path to the file that should be uploaded"),
+    .describe(
+      "Full path to the file that should be uploaded. Must be inside the " +
+        "directory configured via the MCP_UPLOAD_BASE_DIR environment variable.",
+    ),
 });
 
 /**
@@ -40,9 +43,27 @@ export async function uploadFile(
 ): Promise<CallToolResult> {
   const { project_identifier, file_path } = args;
 
+  // File upload is opt-in: it is available only when the operator has declared
+  // an allowed directory via MCP_UPLOAD_BASE_DIR. Without it, refuse rather than
+  // allow uploads from arbitrary paths.
+  if (!appConfig.UPLOAD_BASE_DIR) {
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            "File upload is disabled. Set the MCP_UPLOAD_BASE_DIR environment " +
+            "variable to a directory that contains the files you want to upload, " +
+            "then restart the MCP server. Uploads are restricted to that directory.",
+        },
+      ],
+      isError: true,
+    };
+  }
+
   try {
     // Canonicalize path and enforce upload safety rules (extension, size,
-    // hidden-directory traversal, optional base-dir containment).
+    // hidden-directory traversal, base-dir containment).
     const safePath = validateUploadPath(file_path, {
       allowedExtensions: TEST_MANAGEMENT_ATTACHMENT_EXTENSIONS,
       maxSizeBytes: MAX_ATTACHMENT_UPLOAD_BYTES,

--- a/tests/tools/uploadFile.test.ts
+++ b/tests/tools/uploadFile.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+
+const { cfgMock } = vi.hoisted(() => ({
+  cfgMock: { UPLOAD_BASE_DIR: undefined as string | undefined },
+}));
+vi.mock("../../src/config.js", () => ({ default: cfgMock }));
+
+import { uploadFile } from "../../src/tools/testmanagement-utils/upload-file.js";
+
+const bsConfig: any = {
+  "browserstack-username": "u",
+  "browserstack-access-key": "k",
+};
+
+describe("uploadFile — MCP_UPLOAD_BASE_DIR requirement", () => {
+  it("refuses the upload when MCP_UPLOAD_BASE_DIR is not set", async () => {
+    cfgMock.UPLOAD_BASE_DIR = undefined;
+    const res = await uploadFile(
+      { project_identifier: "P1", file_path: "/tmp/whatever.pdf" },
+      bsConfig,
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("File upload is disabled");
+    expect(res.content[0].text).toContain("MCP_UPLOAD_BASE_DIR");
+  });
+
+  it("passes the gate when set (any later failure is not the gate)", async () => {
+    cfgMock.UPLOAD_BASE_DIR = "/tmp";
+    const res = await uploadFile(
+      { project_identifier: "P1", file_path: "/etc/hostname" }, // outside/ext-invalid
+      bsConfig,
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).not.toContain("File upload is disabled");
+  });
+});


### PR DESCRIPTION
## Summary
Makes the `uploadProductRequirementFile` tool **opt-in**: it works only when the operator has set the `MCP_UPLOAD_BASE_DIR` environment variable to an allowed directory, and uploads are confined to that directory. Without it, the tool refuses instead of accepting an arbitrary local file path.

This closes the residual gap in the upload path: `validateUploadPath` already blocks traversal / hidden-dir / bad-extension / oversized files, and supports a base-directory jail — but that jail was previously **optional**. This change makes it **required** for the document/attachment upload tool, so a caller (or a prompt-injected agent) can't have the tool read files from anywhere on disk.

## Changes
- `testmanagement-utils/upload-file.ts`: refuse with clear guidance when `MCP_UPLOAD_BASE_DIR` is unset ("set it and restart; uploads are restricted to that directory"). When set, the existing `validateUploadPath` containment applies.
- `file_path` schema description now documents the base-dir requirement.
- Tests: refuses when unset; passes the gate when set.

## Scope
Applies to the document/attachment upload tool (`uploadProductRequirementFile`). App-binary uploads (App Live / App Automate) keep their current behaviour (traversal/hidden-dir/extension/size guards remain in force via `validateUploadPath`).

## Testing
`tsc --noEmit` clean; eslint clean; `tests/tools/uploadFile.test.ts` passes (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)