### PR TITLE
fix(server): correct tool hints flagged in marketplace review and make SDK setup output chat-safe

### DIFF
--- a/src/lib/version-resolver.ts
+++ b/src/lib/version-resolver.ts
@@ -3,14 +3,21 @@
  * Else if exact match, returns that
  * Else picks the numerically closest (or first)
  */
+const PRERELEASE_CHANNEL = /\b(beta|dev|alpha|canary|nightly|preview)\b/i;
+
 export function resolveVersion(requested: string, available: string[]): string {
   // strip duplicates & sort
   const uniq = Array.from(new Set(available));
 
   // pick min/max
   if (requested === "latest" || requested === "oldest") {
+    // Prefer stable releases: BrowserStack lists pre-release channels such as
+    // "154.0 beta" / "155.0 dev" alongside stable versions, and "latest"
+    // should never resolve to one of those while a stable version exists.
+    const stable = uniq.filter((v) => !PRERELEASE_CHANNEL.test(v));
+    const candidates = stable.length > 0 ? stable : uniq;
     // try numeric
-    const nums = uniq
+    const nums = candidates
       .map((v) => ({ v, n: parseFloat(v) }))
       .filter((x) => !isNaN(x.n))
       .sort((a, b) => a.n - b.n);
@@ -18,7 +25,7 @@ export function resolveVersion(requested: string, available: string[]): string {
       return requested === "latest" ? nums[nums.length - 1].v : nums[0].v;
     }
     // fallback lex
-    const lex = uniq.slice().sort();
+    const lex = candidates.slice().sort();
     return requested === "latest" ? lex[lex.length - 1] : lex[0];
   }
 

--- a/src/tools/accessibility.ts
+++ b/src/tools/accessibility.ts
@@ -472,7 +472,7 @@ export default function addAccessibilityTools(
     {
       title: "Start Accessibility Scan",
       readOnlyHint: false,
-      openWorldHint: false,
+      openWorldHint: true,
       destructiveHint: false,
       idempotentHint: false,
     },

--- a/src/tools/sdk-utils/common/constants.ts
+++ b/src/tools/sdk-utils/common/constants.ts
@@ -1,5 +1,6 @@
 export const IMPORTANT_SETUP_WARNING =
-  "IMPORTANT: DO NOT SKIP ANY STEP. All the setup steps described below MUST be executed regardless of any existing configuration or setup. This ensures proper BrowserStack SDK setup.";
+  "IMPORTANT: DO NOT SKIP ANY STEP. All the setup steps described below MUST be executed regardless of any existing configuration or setup. This ensures proper BrowserStack SDK setup. " +
+  "If you cannot run commands or edit files in the user's project (e.g. a chat-only client), present every step below to the user in full — including each shell command, the package.json changes, and the complete browserstack.yml contents — instead of summarizing them.";
 
 export const SETUP_PERCY_DESCRIPTION =
   "Set up or expand Percy visual testing configuration with comprehensive coverage for existing projects that might have Percy integrated. This supports both Percy Web Standalone and Percy Automate. Example prompts: Expand percy coverage for this project {project_name}";

--- a/src/tools/selfheal.ts
+++ b/src/tools/selfheal.ts
@@ -679,7 +679,7 @@ export default function addSelfHealTools(
     },
     {
       title: "Prepare Self-Healing Plan",
-      readOnlyHint: true,
+      readOnlyHint: false,
       openWorldHint: false,
       destructiveHint: false,
       idempotentHint: true,

--- a/tests/lib/version-resolver.test.ts
+++ b/tests/lib/version-resolver.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { resolveVersion } from "../../src/lib/version-resolver";
+
+describe("resolveVersion", () => {
+  const versions = ["152.0", "153.0", "154.0 beta", "155.0 dev"];
+
+  it("resolves 'latest' to the newest stable version, skipping beta/dev channels", () => {
+    expect(resolveVersion("latest", versions)).toBe("153.0");
+  });
+
+  it("resolves 'oldest' to the oldest stable version", () => {
+    expect(resolveVersion("oldest", versions)).toBe("152.0");
+  });
+
+  it("falls back to pre-release channels when no stable version exists", () => {
+    expect(resolveVersion("latest", ["154.0 beta", "155.0 dev"])).toBe(
+      "155.0 dev",
+    );
+  });
+
+  it("still returns exact matches, including pre-release channels", () => {
+    expect(resolveVersion("154.0 beta", versions)).toBe("154.0 beta");
+  });
+
+  it("matches by major version", () => {
+    expect(resolveVersion("152", versions)).toBe("152.0");
+  });
+});

--- a/tests/tools/tool-annotations.test.ts
+++ b/tests/tools/tool-annotations.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../src/logger", () => ({
+  default: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+vi.mock("../../src/lib/instrumentation", () => ({ trackMCP: vi.fn() }));
+
+import addAccessibilityTools from "../../src/tools/accessibility";
+import addSelfHealTools from "../../src/tools/selfheal";
+
+const mockConfig = {
+  "browserstack-username": "fake-user",
+  "browserstack-access-key": "fake-key",
+};
+
+// Captures the annotations object passed as the 4th argument to server.tool().
+function collectAnnotations(register: (server: any, config: any) => unknown) {
+  const annotations: Record<string, any> = {};
+  const serverMock = {
+    tool: vi.fn((...toolArgs: any[]) => {
+      annotations[toolArgs[0]] = toolArgs[3];
+    }),
+    server: {
+      getClientVersion: vi.fn().mockReturnValue({ version: "1.0" }),
+      getClientCapabilities: vi.fn().mockReturnValue({}),
+      elicitInput: vi.fn(),
+    },
+  };
+  register(serverMock, mockConfig);
+  return annotations;
+}
+
+// These values were flagged in the OpenAI marketplace review of v1.3.0; the
+// assertions pin the corrected hints so they cannot silently regress.
+describe("tool annotations flagged in marketplace review", () => {
+  it("startAccessibilityScan is open-world: it loads an arbitrary public URL (and can submit login forms)", () => {
+    const annotations = collectAnnotations(addAccessibilityTools);
+    expect(annotations.startAccessibilityScan).toMatchObject({
+      readOnlyHint: false,
+      openWorldHint: true,
+      destructiveHint: false,
+    });
+  });
+
+  it("prepareSelfHealingPlan is not read-only: it drives a code-edit workflow", () => {
+    const annotations = collectAnnotations(addSelfHealTools);
+    expect(annotations.prepareSelfHealingPlan).toMatchObject({
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: false,
+    });
+  });
+});


### PR DESCRIPTION
## Why

The OpenAI marketplace review of v1.3.0 rejected the submission on two points:

1. **Web test case 5** (`setupBrowserStackAutomateTests`): "The response didn't include the required setup commands and configuration."
2. **Tool annotations**: `openWorldHint: false` on `startAccessibilityScan` and `readOnlyHint: true` on `prepareSelfHealingPlan`.

Tracking page: https://browserstack.atlassian.net/wiki/spaces/ENG/pages/6495306001 (see "Review round 1").

## What changed

### Tool hints
- `startAccessibilityScan`: `openWorldHint` false → **true**. The scanner loads an arbitrary user-supplied public URL and, with a form auth config, submits a login form on that site. OpenAI's definition of open-world explicitly covers read-only internet access and form submission; `runBrowserLiveSession` was already `true` for the same reason.
- `prepareSelfHealingPlan`: `readOnlyHint` true → **false** (`destructiveHint` stays `false`). The server writes nothing, but the tool exists to drive a code-edit workflow, so clients should confirm before invoking it rather than auto-invoke it as read-only.
- New `tests/tools/tool-annotations.test.ts` pins both values.

### Test case 5
- The tool output was already complete (all 9 steps, including the full `browserstack.yml`). The failure is that the output is written for agents that *execute* steps ("DO NOT SKIP ANY STEP … MUST be executed"); ChatGPT cannot run commands, so it summarised instead of relaying the commands. The setup banner now tells chat-only clients to present every step, command and the full YAML verbatim. Executing agents keep the existing imperative behaviour.
- `resolveVersion("latest")` picked `154.0 beta` for Chrome because pre-release channels were not skipped. It now prefers stable versions and only falls back to beta/dev when no stable version exists (also fixes the "154.0 dev" seen in the Live-session test case). New `tests/lib/version-resolver.test.ts`.

## Not changed (on purpose)
- `setupBrowserStackAutomateTests` / `setupBrowserStackAppAutomateTests` stay `readOnlyHint: true` — they generate documentation, call no write APIs, and the reviewer accepted them.
- The RCA follow-up trailer in the SDK output is unchanged; it drives product behaviour in IDE agents.

## Verification
- `npm run build` passes locally (lint, format, 426 tests, tsc).
- Called `setupBrowserStackAutomateTests` with the exact test-case-5 inputs (nodejs / playwright / playwright, Windows 11 + Chrome latest, project `mcp-demo`) and confirmed all setup commands and the YAML are present.

## Follow-up (not in this PR)
Version bump to 1.3.3 → release → bump wrapper dep + deploy → update portal justifications → re-run Scan Tools → re-verify positive cases **inside ChatGPT** → resubmit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
